### PR TITLE
ScreenInfo and ItemMover fix for other resolutions

### DIFF
--- a/BH/Modules/ItemMover/ItemMover.cpp
+++ b/BH/Modules/ItemMover/ItemMover.cpp
@@ -39,7 +39,7 @@ void ItemMover::Init() {
 	int screenHeight = *p_D2CLIENT_ScreenSizeY;
 	//PrintText(1, "Got screensize %d, %d", screenWidth, screenHeight);
 
-	if (screenWidth == 640 && screenHeight == 480) {
+	if (screenWidth != 800 || screenHeight != 600) {
 		classicStashLayout = InventoryLayoutMap["Bank Page 1"];
 		lodStashLayout = InventoryLayoutMap["Big Bank Page 1"];
 		inventoryLayout = InventoryLayoutMap["Amazon"];  // all character types have the same layout

--- a/BH/Modules/ScreenInfo/ScreenInfo.cpp
+++ b/BH/Modules/ScreenInfo/ScreenInfo.cpp
@@ -290,7 +290,7 @@ void ScreenInfo::OnAutomapDraw() {
 				key.replace(key.find("%" + automap[n].key + "%"), automap[n].key.length() + 2, automap[n].value);
 		}
 		if (key.length() > 0)
-			Texthook::Draw(790, (y+=16), Right,0,Gold,"%s", key.c_str());
+			Texthook::Draw(*p_D2CLIENT_ScreenSizeX - 10, (y+=16), Right,0,Gold,"%s", key.c_str());
 	}
 
 	delete [] level;

--- a/BH/Modules/ScreenInfo/ScreenInfo.cpp
+++ b/BH/Modules/ScreenInfo/ScreenInfo.cpp
@@ -204,6 +204,9 @@ void ScreenInfo::OnDraw() {
 	if (Toggles["Experience Meter"].state) {
 		drawExperienceInfo();
 	}
+
+	bhText->SetBaseX(*p_D2CLIENT_ScreenSizeX - 5);
+	bhText2->SetBaseY(*p_D2CLIENT_ScreenSizeY - 8);
 }
 
 void ScreenInfo::drawExperienceInfo(){
@@ -238,7 +241,7 @@ void ScreenInfo::drawExperienceInfo(){
 	}
 	sprintf_s(sExp, "%00.2f%% (%s%00.2f%%) [%s%.2f%s/s]", pExp, expGainPct >= 0 ? "+" : "", expGainPct, expPerSecond >= 0 ? "+" : "", expPerSecond, unit);
 
-	Texthook::Draw(300, 600 - 60, Center, 6, White, "%s", sExp);
+	Texthook::Draw((*p_D2CLIENT_ScreenSizeX / 2) - 100, *p_D2CLIENT_ScreenSizeY - 60, Center, 6, White, "%s", sExp);
 }
 
 void ScreenInfo::OnAutomapDraw() {
@@ -370,6 +373,9 @@ void ScreenInfo::OnGameExit() {
 	DiabloBlocked = false;
 	BaalBlocked = false;
 	ReceivedQuestPacket = false;
+
+	bhText->SetBaseX(795);
+	bhText2->SetBaseY(592);
 }
 
 


### PR DESCRIPTION
Allows the hack's screen info and item mover to properly function when the resolution is cranked up to 1066x600. Or any resolution, for that matter.
![screenshot005](https://cloud.githubusercontent.com/assets/26683324/25560050/30d1d94c-2cfe-11e7-9e78-e8ca1076eb7c.jpg)
