### PR TITLE
add sell price item condition

### DIFF
--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -797,6 +797,8 @@ void Condition::BuildConditions(vector<Condition*> &conditions, string token) {
 			Condition::AddOperand(conditions, new ItemStatCondition(stat1, stat2, operation, value));
 		}
 
+	} else if (key.compare(0, 5, "PRICE") == 0) {
+		Condition::AddOperand(conditions, new ItemPriceCondition(operation, value));
 	}
 
 	for (vector<Condition*>::iterator it = endConditions.begin(); it != endConditions.end(); it++) {
@@ -1201,6 +1203,14 @@ bool ItemStatCondition::EvaluateInternalFromPacket(ItemInfo *info, Condition *ar
 		}
 		return IntegerCompare(num, operation, targetStat);
 	}
+	return false;
+}
+
+bool ItemPriceCondition::EvaluateInternal(UnitItemInfo *uInfo, Condition *arg1, Condition *arg2) {
+	return IntegerCompare(D2COMMON_GetItemPrice(D2CLIENT_GetPlayerUnit(), uInfo->item, D2CLIENT_GetDifficulty(), (DWORD)D2CLIENT_GetQuestInfo(), 0x201, 1), operation, targetStat);
+}
+bool ItemPriceCondition::EvaluateInternalFromPacket(ItemInfo *info, Condition *arg1, Condition *arg2) {
+	// TODO: Implement later
 	return false;
 }
 

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -422,6 +422,20 @@ private:
 	bool EvaluateInternalFromPacket(ItemInfo *info, Condition *arg1, Condition *arg2);
 };
 
+class ItemPriceCondition : public Condition
+{
+public:
+	ItemPriceCondition(BYTE op, unsigned int target)
+		: operation(op), targetStat(target) {
+		conditionType = CT_Operand;
+	};
+private:
+	BYTE operation;
+	unsigned int targetStat;
+	bool EvaluateInternal(UnitItemInfo *uInfo, Condition *arg1, Condition *arg2);
+	bool EvaluateInternalFromPacket(ItemInfo *info, Condition *arg1, Condition *arg2);
+};
+
 class ResistAllCondition : public Condition
 {
 public:


### PR DESCRIPTION
Add the ability to color items based on the sell price. Example used in picture. I don't know if this info is exposed in the drop packet so unfortunately `%MAP%` would not announce these drops.

`ItemDisplay[PRICE>5000]: %ORANGE%%NAME%`

![image](https://user-images.githubusercontent.com/1458109/48881205-170e3900-ede2-11e8-9755-a8a89332b1f3.png)
