### PR TITLE
Document FTJ patch

### DIFF
--- a/BH/Modules/Bnet/Bnet.cpp
+++ b/BH/Modules/Bnet/Bnet.cpp
@@ -171,6 +171,10 @@ void Bnet::RemovePassPatch() {
 
 void __declspec(naked) FailToJoin_Interception()
 {
+	/*
+	Changes the amount of time, in milliseconds, that we wait for the loading
+	door to open before the client confirms that it failed to join the game.
+	*/
 	__asm
 	{
 		cmp esi, Bnet::failToJoin;


### PR DESCRIPTION
This adds a single comment that documents exactly what the Failed to Join (FTJ) patch does.