### PR TITLE
Add cmake support. Fix couple of issues with linking w/ VS 15 2017. Fix crash on reload config.

### DIFF
--- a/BH/CMakeLists.txt
+++ b/BH/CMakeLists.txt
@@ -1,0 +1,53 @@
+project(BH)
+
+set(SOURCE_FILES "AsyncDrawBuffer.cpp"
+                 "BH.cpp"
+                 "BitReader.cpp"
+                 "Common.cpp"
+                 "Config.cpp"
+                 "D2Handlers.cpp"
+                 "D2Helpers.cpp"
+                 "D2Intercepts.cpp"
+                 "D2Stubs.cpp"
+                 "D2Version.cpp"
+                 "DllMain.cpp"
+                 "JSONObject.cpp"
+                 "MPQInit.cpp"
+                 "MPQReader.cpp"
+                 "Mustache.cpp"
+                 "Patch.cpp"
+                 "TableReader.cpp"
+                 "Task.cpp")
+
+set(MODULE_SOURCES "Modules/Module.cpp"
+                   "Modules/ModuleManager.cpp"
+                   "Modules/AutoTele/AutoTele.cpp"
+                   "Modules/Bnet/Bnet.cpp"
+                   "Modules/ChatColor/ChatColor.cpp"
+                   "Modules/Gamefilter/Gamefilter.cpp"
+                   "Modules/Item/Item.cpp"
+                   "Modules/Item/ItemDisplay.cpp"
+                   "Modules/ItemMover/ItemMover.cpp"
+                   "Modules/Maphack/Maphack.cpp"
+                   "Modules/Party/Party.cpp"
+                   "Modules/ScreenInfo/ScreenInfo.cpp"
+                   "Modules/StashExport/StashExport.cpp")
+
+set(DRAWING_SOURCES "Drawing/Hook.cpp"
+                    "Drawing/Advanced/Checkhook/Checkhook.cpp"
+                    "Drawing/Advanced/Colorhook/Colorhook.cpp"
+                    "Drawing/Advanced/Combohook/Combohook.cpp"
+                    "Drawing/Advanced/Inputhook/Inputhook.cpp"
+                    "Drawing/Advanced/Keyhook/Keyhook.cpp"
+                    "Drawing/Basic/Boxhook/Boxhook.cpp"
+                    "Drawing/Basic/Crosshook/Crosshook.cpp"
+                    "Drawing/Basic/Framehook/Framehook.cpp"
+                    "Drawing/Basic/Linehook/Linehook.cpp"
+                    "Drawing/Basic/Texthook/Texthook.cpp"
+                    "Drawing/Stats/StatsDisplay.cpp"
+                    "Drawing/UI/UI.cpp"
+                    "Drawing/UI/UITab.cpp")
+
+set(SOURCE_FILES ${SOURCE_FILES} ${MODULE_SOURCES} ${DRAWING_SOURCES})
+add_library(BH ${SOURCE_FILES})
+target_link_libraries(BH ${STORM_LIBRARY} Shlwapi)

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -1302,8 +1302,8 @@ bool ItemPriceCondition::EvaluateInternal(UnitItemInfo *uInfo, Condition *arg1, 
 	return IntegerCompare(D2COMMON_GetItemPrice(D2CLIENT_GetPlayerUnit(), uInfo->item, D2CLIENT_GetDifficulty(), (DWORD)D2CLIENT_GetQuestInfo(), 0x201, 1), operation, targetStat);
 }
 bool ItemPriceCondition::EvaluateInternalFromPacket(ItemInfo *info, Condition *arg1, Condition *arg2) {
-	// TODO: Implement later
-	return false;
+    UnitAny *uAny = D2CLIENT_FindClientSideUnit(info->id, UNIT_ITEM);
+	return IntegerCompare(D2COMMON_GetItemPrice(D2CLIENT_GetPlayerUnit(), uAny, D2CLIENT_GetDifficulty(), (DWORD)D2CLIENT_GetQuestInfo(), 0x201, 1), operation, targetStat);
 }
 
 bool ResistAllCondition::EvaluateInternal(UnitItemInfo *uInfo, Condition *arg1, Condition *arg2) {

--- a/BH/Modules/Maphack/Maphack.cpp
+++ b/BH/Modules/Maphack/Maphack.cpp
@@ -80,7 +80,7 @@ void Maphack::ReadConfig() {
 		int monsterId = -1;
 		stringstream ss((*it).first);
 		if ((ss >> monsterId).fail()) {
-			++it;
+			continue;
 		} else {
 			int monsterColor = StringToNumber((*it).second);
 			automapMonsterColors[monsterId] = monsterColor;
@@ -94,7 +94,7 @@ void Maphack::ReadConfig() {
 		int monsterId = -1;
 		stringstream ss((*it).first);
 		if ((ss >> monsterId).fail()) {
-			++it;
+			continue;
 		} else {
 			int lineColor = StringToNumber((*it).second);
 			automapMonsterLines[monsterId] = lineColor;
@@ -107,7 +107,7 @@ void Maphack::ReadConfig() {
 		int monsterId = -1;
 		stringstream ss((*it).first);
 		if ((ss >> monsterId).fail()) {
-			++it;
+			continue;
 		} else {
 			automapHiddenMonsters.push_back(monsterId);
 		}

--- a/BH/TableReader.cpp
+++ b/BH/TableReader.cpp
@@ -201,11 +201,6 @@ bool TableReader::loadMPQData(std::string archiveName, Table &table)
 	return true;
 }
 
-inline
-void Table::addEntry(JSONObject *entry){
-	data->add(entry);
-}
-
 void Table::removeWhere(std::function<bool(JSONElement*)> predicate){
 	data->removeWhere(predicate);
 }
@@ -213,11 +208,6 @@ void Table::removeWhere(std::function<bool(JSONElement*)> predicate){
 Table::Table(std::string filePath) : data(new JSONArray()){
 	Table *_this = this;
 	TableReader::readTable(filePath, *_this);
-}
-
-inline
-JSONObject* Table::entryAt(int index){
-	return data->getObject(index);
 }
 
 bool Table::dump(std::string filePath){

--- a/BH/TableReader.h
+++ b/BH/TableReader.h
@@ -64,3 +64,13 @@ public:
 
 	static bool isInitialized();
 };
+
+inline
+void Table::addEntry(JSONObject *entry){
+	data->add(entry);
+}
+
+inline
+JSONObject* Table::entryAt(int index){
+	return data->getObject(index);
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.7)
+find_library(STORM_LIBRARY NAMES StormLib HINTS "ThirdParty")
+add_subdirectory("BH")

--- a/README.md
+++ b/README.md
@@ -590,3 +590,9 @@ Which renders as:
 * Chipped Ruby (L1) **x8**
 
 * Flawed Emerald (L1) **x7**
+
+# Building
+
+To build with CMake, first install "Visual Studio Build Tools 2017" and a version of CMake>=3.7. Visual Studio Build Tools comes with a "Developer Command Prompt" that sets up the path with the right compilers and build tools. Next, create a build directory within the project root directory and make it the current working directory. Then, run the command `cmake -G"Visual Studio 15 2017" -DCMAKE_BUILD_SHARED_LIBS=TRUE -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE ..` (save this command as a bat script if you like). This will create all necessary build files. Next, run `cmake --build . --config Release` to build the project.
+
+To enable multi-processor support when buildling, set the CXXFLAGS environment variable with `set CXXFLAGS=/MP` prior to running the cmake command above.


### PR DESCRIPTION
I also added the "from packet" price condition check. This allows the price condition to override other hiding filters (but only when %MAP% is used, as normal). Before, if you had something like the following, then the item would still be hidden. This is no longer the case with this patch.
`ItemDisplay[PRICE>10000]: %NAME%%MAP%`
`ItemDisplay[some_item_worth_more_than_10000]:`