### PR TITLE
Multiple ItemConfig's

### DIFF
--- a/BH/Drawing/Hook.h
+++ b/BH/Drawing/Hook.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <list>
 #include <Windows.h>
+#include <string>
 
 namespace Drawing {
 	// HookGroups allow use of the basic hooks(Line,Text,Box,Frame)

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -333,6 +333,19 @@ namespace ItemDisplay {
 
 		item_display_initialized = true;
 		rules.clear();
+
+		vector<pair<string, string>> itemConfigs;
+		BH::config->ReadMapList("ItemConfig", itemConfigs);
+		for (pair<string, string> pair : itemConfigs) {
+			Config* c = new Config(pair.second);
+			if (!c->Parse()) {
+				string msg = "Could not find ItemConfig.\nAttempted to load " +
+					pair.second + " (failed)";
+				MessageBox(NULL, msg.c_str(), "Failed to load ItemConfig", MB_OK);
+			}
+			c->ReadMapList("ItemDisplay", rules);
+		}
+
 		BH::config->ReadMapList("ItemDisplay", rules);
 		for (unsigned int i = 0; i < rules.size(); i++) {
 			string buf;


### PR DESCRIPTION
allow multiple external item configs to be loaded. ex:
```
//ItemConfig[]: ../BH/early_ladder.cfg
ItemConfig[]: ../BH/socketables.cfg
ItemConfig[]: ../BH/rares.cfg
ItemConfig[]: ../BH/charms.cfg
```
you can still define all your itemdisplay rules in the main `BH.cfg` file, this just allows you to externalize that if you want to. makes it easy to turn on and off groups of rules like `early_ladder.cfg` or to easily find a rule you are looking for.