### PR TITLE
Added support for filtering based on quality level.

### DIFF
--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -599,6 +599,8 @@ void Condition::BuildConditions(vector<Condition*> &conditions, string token) {
 		Condition::AddOperand(conditions, new FlagsCondition(ITEM_IDENTIFIED));
 	} else if (key.compare(0, 4, "ILVL") == 0) {
 		Condition::AddOperand(conditions, new ItemLevelCondition(operation, value));
+	} else if (key.compare(0, 4, "QLVL") == 0) {
+		Condition::AddOperand(conditions, new QualityLevelCondition(operation, value));
 	} else if (key.compare(0, 4, "ALVL") == 0) {
 		Condition::AddOperand(conditions, new AffixLevelCondition(operation, value));
 	} else if (key.compare(0, 4, "CLVL") == 0) {
@@ -1045,6 +1047,15 @@ bool ItemLevelCondition::EvaluateInternal(UnitItemInfo *uInfo, Condition *arg1, 
 }
 bool ItemLevelCondition::EvaluateInternalFromPacket(ItemInfo *info, Condition *arg1, Condition *arg2) {
 	return IntegerCompare(info->level, operation, itemLevel);
+}
+
+bool QualityLevelCondition::EvaluateInternal(UnitItemInfo *uInfo, Condition *arg1, Condition *arg2) {
+	BYTE qlvl = uInfo->attrs->qualityLevel;
+	return IntegerCompare(qlvl, operation, qualityLevel);
+}
+bool QualityLevelCondition::EvaluateInternalFromPacket(ItemInfo *info, Condition *arg1, Condition *arg2) {
+	int qlvl = info->attrs->qualityLevel;
+	return IntegerCompare(qlvl, operation, qualityLevel);
 }
 
 bool AffixLevelCondition::EvaluateInternal(UnitItemInfo *uInfo, Condition *arg1, Condition *arg2) {

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -312,6 +312,17 @@ private:
 	bool EvaluateInternalFromPacket(ItemInfo *info, Condition *arg1, Condition *arg2);
 };
 
+class QualityLevelCondition : public Condition
+{
+public:
+	QualityLevelCondition(BYTE op, BYTE qlvl) : qualityLevel(qlvl), operation(op) { conditionType = CT_Operand; };
+private:
+	BYTE operation;
+	BYTE qualityLevel;
+	bool EvaluateInternal(UnitItemInfo *uInfo, Condition *arg1, Condition *arg2);
+	bool EvaluateInternalFromPacket(ItemInfo *info, Condition *arg1, Condition *arg2);
+};
+
 class AffixLevelCondition : public Condition
 {
 public:


### PR DESCRIPTION
This is useful for selecting katars capable of staffmods, for example. Also useful for identifying clvl 8 imbue bases.

line for readme:
* Add support for filters based on item quality level. Use the `QLVL` keyword. For example, `SIN QLVL>40` would select all katars capable of spawning staffmods.