### PR TITLE
Added support for filtering based on crafted quality.

### DIFF
--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -581,6 +581,8 @@ void Condition::BuildConditions(vector<Condition*> &conditions, string token) {
 		Condition::AddOperand(conditions, new QualityCondition(ITEM_QUALITY_RARE));
 	} else if (key.compare(0, 3, "UNI") == 0) {
 		Condition::AddOperand(conditions, new QualityCondition(ITEM_QUALITY_UNIQUE));
+	} else if (key.compare(0, 5, "CRAFT") == 0) {
+		Condition::AddOperand(conditions, new QualityCondition(ITEM_QUALITY_CRAFT));
 	} else if (key.compare(0, 2, "RW") == 0) {
 		Condition::AddOperand(conditions, new FlagsCondition(ITEM_RUNEWORD));
 	} else if (key.compare(0, 4, "NMAG") == 0) {


### PR DESCRIPTION
Useful for forcing crafted item names orange, especially if colored tags are prepended to item names.

line for readme:
* Added `CRAFT` keyword for selecting crafted items. This works similar to `UNI`, `SET`, etc.