### PR TITLE
Rule::Evaluate speed up

### DIFF
--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -343,13 +343,11 @@ namespace ItemDisplay {
 			}
 
 			LastConditionType = CT_None;
-			Rule *r = new Rule();
 			vector<Condition*> RawConditions;
 			for (vector<string>::iterator tok = tokens.begin(); tok < tokens.end(); tok++) {
 				Condition::BuildConditions(RawConditions, (*tok));
 			}
-			Condition::ProcessConditions(RawConditions, r->conditions);
-			BuildAction(&(rules[i].second), &(r->action));
+			Rule *r = new Rule(RawConditions, &(rules[i].second));
 
 			RuleList.push_back(r);
 			if (r->action.colorOnMap != UNDEFINED_COLOR ||
@@ -371,6 +369,12 @@ namespace ItemDisplay {
 		MapRuleList.clear();
 		IgnoreRuleList.clear();
 	}
+}
+
+Rule::Rule(vector<Condition*> &inputConditions, string *str) {
+	Condition::ProcessConditions(inputConditions, conditions);
+	BuildAction(str, &action);
+	conditionStack.reserve(conditions.size()); // TODO: too large?
 }
 
 void BuildAction(string *str, Action *act) {

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -520,7 +520,11 @@ struct Action {
 struct Rule {
 	vector<Condition*> conditions;
 	Action action;
+	vector<Condition*> conditionStack;
 
+	Rule(vector<Condition*> &inputConditions, string *str);
+
+	// TODO: Should this really be defined in the header? This will force it to be inlined AFAIK. -ybd
 	// Evaluate conditions which are in Reverse Polish Notation
 	bool Evaluate(UnitItemInfo *uInfo, ItemInfo *info) {
 		if (conditions.size() == 0) {
@@ -529,7 +533,12 @@ struct Rule {
 
 		bool retval;
 		try {
-			vector<Condition*> conditionStack;
+			// conditionStack was previously declared on the stack within this function. This caused
+			// excessive allocaiton calls and was limiting the speed of the item display (causing
+			// frame rate drops with complex item displays while ALT was held down). Moving this vector
+			// to the object level, preallocating size, and using the resize(0) method to clear avoids
+			// excessive reallocation.
+			conditionStack.resize(0); 
 			for (unsigned int i = 0; i < conditions.size(); i++) {
 				Condition *input = conditions[i];
 				if (input->conditionType == CT_Operand) {


### PR DESCRIPTION
I was testing out a new BH config I made that was quite complex and noticed that holding ALT would significantly drop the frame rate. I profiled the code and found the source of the problem to be excessive reallocation calls within the Rule::Evaluate function.

After some investigation, this was because the conditionStack vector was defined locally in the Evaluate() function. So each time Evaluate() was called, the conditionStack would have to be reallocated. Not only that, but it would potentially have to be dynamically resized as push_back() was called, and it also had to be deleted at the end of the function.

I moved the conditionStack to a struct member and use the resize(0) method to clear the contents without forcing reallocation. This seems to have given a pretty substantial performance gain. I don't really see the frame rate drop anymore. I also see that the operator delete[] call is no longer present in the call stack (was previously very high % exclusive).

Someone might want to check the size I initially reserve for conditionStack in case it's too large. Also, I think it might be a good idea to move Rule::Evaluate definition to the cpp file.

Before:
![Capture_1 9 7](https://user-images.githubusercontent.com/39288882/76058272-c9fb9b00-5f30-11ea-816d-7480ac50616e.PNG)

After:
![Capture_fixed](https://user-images.githubusercontent.com/39288882/76058273-ca943180-5f30-11ea-8984-bb029cee9a55.PNG)

Sleepy files:
[BH_profiling.zip](https://github.com/planqi/slashdiablo-maphack/files/4296776/BH_profiling.zip)

