### PR TITLE
UI.ini file frequent write fix

### DIFF
--- a/BH/Drawing/UI/UI.cpp
+++ b/BH/Drawing/UI/UI.cpp
@@ -174,16 +174,20 @@ void UI::OnDraw() {
 	}
 }
 
-void UI::SetDragged(bool state) { 
+void UI::SetDragged(bool state, bool write_file) {
 	Lock(); 
 	dragged = state; 
-	if (!state) {
+	if (!state && write_file) {
 		WritePrivateProfileString(name.c_str(), "X", to_string<unsigned int>(GetX()).c_str(), string(BH::path + "UI.ini").c_str());
 		WritePrivateProfileString(name.c_str(), "Y", to_string<unsigned int>(GetY()).c_str(), string(BH::path + "UI.ini").c_str());
 		WritePrivateProfileString(name.c_str(), "minimizedX", to_string<unsigned int>(GetMinimizedX()).c_str(), string(BH::path + "UI.ini").c_str());
 		WritePrivateProfileString(name.c_str(), "minimizedY", to_string<unsigned int>(GetMinimizedY()).c_str(), string(BH::path + "UI.ini").c_str());
 	}
 	Unlock(); 
+}
+
+void UI::SetDragged(bool state) {
+    SetDragged(state, false);
 }
 
 void UI::SetMinimized(bool newState) { 
@@ -228,7 +232,7 @@ bool UI::OnLeftClick(bool up, unsigned int mouseX, unsigned int mouseY) {
 			}
 			else
 			{
-				SetDragged(false);
+				SetDragged(false, true);
 				if(!up) {
 					PrintText(7, "CTRL-click to open settings" );
 					PrintText(7, "Shift-drag to move" );
@@ -248,7 +252,7 @@ bool UI::OnLeftClick(bool up, unsigned int mouseX, unsigned int mouseY) {
 		} 
 		else
 		{
-			SetDragged(false);
+			SetDragged(false, true);
 			if( startX == mouseX && startY == mouseY && GetAsyncKeyState(VK_CONTROL) )
 			{
 				PrintText(135, "Right Click to Close" );
@@ -271,7 +275,7 @@ bool UI::OnLeftClick(bool up, unsigned int mouseX, unsigned int mouseY) {
 		return true;
 	}
 	SetActive(false);
-	SetDragged(false);
+	SetDragged(false, false);
 	return false;
 }
 

--- a/BH/Drawing/UI/UI.h
+++ b/BH/Drawing/UI/UI.h
@@ -55,7 +55,8 @@ namespace Drawing {
 			void SetActive(bool newState) { Lock(); active = newState; Unlock(); };
 			void SetMinimized(bool newState);
 			void SetName(std::string newName) { Lock(); name = newName;  Unlock(); };
-			void SetDragged(bool state);
+			void SetDragged(bool state, bool write_file); // only write config to file if write_file is true
+			void SetDragged(bool state); // never writes the config file
 			void SetZOrder(unsigned int newZ) { Lock(); zOrder = newZ; Unlock(); };
 
 			UITab* GetActiveTab() { if (!currentTab) { currentTab = (*Tabs.begin()); } return currentTab; };

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -343,13 +343,11 @@ namespace ItemDisplay {
 			}
 
 			LastConditionType = CT_None;
-			Rule *r = new Rule();
 			vector<Condition*> RawConditions;
 			for (vector<string>::iterator tok = tokens.begin(); tok < tokens.end(); tok++) {
 				Condition::BuildConditions(RawConditions, (*tok));
 			}
-			Condition::ProcessConditions(RawConditions, r->conditions);
-			BuildAction(&(rules[i].second), &(r->action));
+			Rule *r = new Rule(RawConditions, &(rules[i].second));
 
 			RuleList.push_back(r);
 			if (r->action.colorOnMap != UNDEFINED_COLOR ||
@@ -371,6 +369,12 @@ namespace ItemDisplay {
 		MapRuleList.clear();
 		IgnoreRuleList.clear();
 	}
+}
+
+Rule::Rule(vector<Condition*> &inputConditions, string *str) {
+	Condition::ProcessConditions(inputConditions, conditions);
+	BuildAction(str, &action);
+	conditionStack.reserve(conditions.size()); // TODO: too large?
 }
 
 void BuildAction(string *str, Action *act) {

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -520,7 +520,11 @@ struct Action {
 struct Rule {
 	vector<Condition*> conditions;
 	Action action;
+	vector<Condition*> conditionStack;
 
+	Rule(vector<Condition*> &inputConditions, string *str);
+
+	// TODO: Should this really be defined in the header? This will force it to be inlined AFAIK. -ybd
 	// Evaluate conditions which are in Reverse Polish Notation
 	bool Evaluate(UnitItemInfo *uInfo, ItemInfo *info) {
 		if (conditions.size() == 0) {
@@ -529,7 +533,12 @@ struct Rule {
 
 		bool retval;
 		try {
-			vector<Condition*> conditionStack;
+			// conditionStack was previously declared on the stack within this function. This caused
+			// excessive allocaiton calls and was limiting the speed of the item display (causing
+			// frame rate drops with complex item displays while ALT was held down). Moving this vector
+			// to the object level, preallocating size, and using the resize(0) method to clear avoids
+			// excessive reallocation.
+			conditionStack.resize(0); 
 			for (unsigned int i = 0; i < conditions.size(); i++) {
 				Condition *input = conditions[i];
 				if (input->conditionType == CT_Operand) {


### PR DESCRIPTION
I ran a profiler during a CS run with and without maphack. I saw that we were spending a lot of time creating files (ZwCreateFile). I tracked this down to a SetDragged() call in OnLeftClick. There was an unconditional call to this each time the left mouse button was clicked.

I didn't want to break anything, so I made the minimal changes so that the file is not written on the unconditional SetDragged() call.

Here is the profiler result without maphack:
![image](https://user-images.githubusercontent.com/39288882/76144426-17613080-6035-11ea-9119-c9092f459bea.png)

Here is the profiler result with maphack (1.9.7), but with the [Rule::Evaluate allocation fix:](https://github.com/planqi/slashdiablo-maphack/pull/37)
![image](https://user-images.githubusercontent.com/39288882/76144437-42e41b00-6035-11ea-9291-700fac4fdff7.png)

Here is the result after this fix (again 1.9.7 with the allocation fix):
![image](https://user-images.githubusercontent.com/39288882/76144465-9ce4e080-6035-11ea-826b-e456461cd493.png)

Sleepy logs:
[BH_profiling_ini_fix.zip](https://github.com/planqi/slashdiablo-maphack/files/4301866/BH_profiling_ini_fix.zip)

Note this PR also includes the Rule::Evaluate allocation fix.