### PR TITLE
Require %CONTINUE% to process multiple map commands

### DIFF
--- a/BH/Modules/Maphack/Maphack.cpp
+++ b/BH/Modules/Maphack/Maphack.cpp
@@ -537,6 +537,7 @@ void Maphack::OnAutomapDraw() {
 										Drawing::Linehook::Draw(MyPos.x, MyPos.y, automapLoc.x, automapLoc.y, lineColor);
 									}
 								});
+								if ((*it)->action.stopProcessing) break;
 							}
 						}
 					}


### PR DESCRIPTION
Require %CONTINUE% to be used to continue processing map commands from different lines. This makes the map commands behave identically to the name commands.

Example:
```
ItemDisplay[CHEST NMAG ETH !SUP SOCK=0 DEF>866]: %PURPLE%0%MAP% %NAME%
ItemDisplay[CHEST NMAG ETH !SUP SOCK=0 DEF>666]: %WHITE%0%MAP% %NAME%
```

Before the change, an armor matching the first line gets a purple 0 but a white map box. The name is taken from the first line, but the map condition is taken from the second (effectively).

After the change, an armor matching the first condition gets a purple 0 and a purple map box. The map condition and name are both taken from the same line.

To restore the original behavior:

```
ItemDisplay[CHEST NMAG ETH !SUP SOCK=0 DEF>866]: %PURPLE%0%MAP% %NAME%%CONTINUE%
ItemDisplay[CHEST NMAG ETH !SUP SOCK=0 DEF>666 DEF<867]: %WHITE%0 %NAME%%CONTINUE%
ItemDisplay[CHEST NMAG ETH !SUP SOCK=0 DEF>666]: %WHITE%%MAP% %NAME%
```

It's ugly because it's probably not what you meant to do in the first place.

This will require changes to existing config files for anyone relying on all %MAP%, %border%, etc. actions to be processed regardless of %CONTINUE%. We could add a toggle for legacy support, but I think that it might be better to just force the use of %CONTINUE%.

Here's an example from @planqi's config:

```
// Add border to all but really low runes
ItemDisplay[RUNE>12]: %name%%border-d0%%CONTINUE%
//No Indicator, White text, no map
ItemDisplay[RUNE<13]: %WHITE%* %RUNENAME% * (%RUNENUM%)//%dot-20%
//Put lower runes on map when lower clvl
ItemDisplay[RUNE<13 CLVL<70]: %name%%dot-20%
//Grey Indicator, Orange text, grey map
ItemDisplay[RUNE<20 RUNE>12]: %GRAY%0 %ORANGE%* %RUNENAME% * (%RUNENUM%)
//Lem - Gul: Red Indicator, Orange text, red map dot
ItemDisplay[RUNE>19 RUNE<26]: %RED%0 %ORANGE%* %RUNENAME% * (%RUNENUM%)%dot-0a%
//Vex - Zod: Purple Indicator, Orange text, purple map dot
ItemDisplay[RUNE>25]: %PURPLE%0 %ORANGE%* %RUNENAME% * (%RUNENUM%)%dot-9b%
```

This line needs continue:

```
ItemDisplay[RUNE<13]: %WHITE%* %RUNENAME% * (%RUNENUM%)%CONTINUE%//%dot-20%
```