### PR TITLE
Improve party organization with auto-party

### DIFF
--- a/BH/Modules/Party/Party.h
+++ b/BH/Modules/Party/Party.h
@@ -14,11 +14,14 @@ class Party : public Module {
 		map<std::string, bool> LootingPermission;
 		void CheckParty();
 		int c;
+		WORD min_party_id;
+		bool min_party_id_valid;
 	public:
-		Party() : Module("Party") {};
+		Party() : Module("Party"), min_party_id(0xFFFF), min_party_id_valid(false) {};
 		void OnLoad();
 		void OnUnload();
 		void OnLoop();
 		void OnKey(bool up, BYTE key, LPARAM lParam, bool* block);
 		void OnGameExit();
+		void OnGameJoin();
 };


### PR DESCRIPTION
When joining a game, players try to form parties as before. That is they freely send invites and accept them. After all players are in a party, we then check that all players are in the same party. If they aren't, the players with the higher wPartyId will leave and then join the party with the lowest wPartyId.