### PR TITLE
Improve party organization with auto-party

### DIFF
--- a/BH/CMakeLists.txt
+++ b/BH/CMakeLists.txt
@@ -50,4 +50,5 @@ set(DRAWING_SOURCES "Drawing/Hook.cpp"
 
 set(SOURCE_FILES ${SOURCE_FILES} ${MODULE_SOURCES} ${DRAWING_SOURCES})
 add_library(BH ${SOURCE_FILES})
+target_include_directories(BH PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../ThirdParty/cpp-lru-cache/include)
 target_link_libraries(BH ${STORM_LIBRARY} Shlwapi)

--- a/BH/Common.cpp
+++ b/BH/Common.cpp
@@ -123,11 +123,13 @@ int StringToNumber(std::string str) {
 	return ret;
 }
 
+// This function prints at most 151 characters (152 including null)
+// TODO: Fix this so this limitation
 void PrintText(DWORD Color, char *szText, ...) {
 	char szBuffer[152] = {0};
 	va_list Args;
 	va_start(Args, szText);
-	vsprintf_s(szBuffer, 152, szText, Args);
+	vsnprintf_s(szBuffer, 152, _TRUNCATE, szText, Args);
 	va_end(Args); 
 	wchar_t Buffer[0x130];
 	MultiByteToWideChar(CODE_PAGE, 1, szBuffer, 152, Buffer, 304);

--- a/BH/Constants.h
+++ b/BH/Constants.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define BH_VERSION "BH 1.9.8alpha2"
+#define BH_VERSION "BH 1.9.8alpha3"
 
 #define CODE_PAGE 1252 // windows-1252	ANSI Latin 1; Western European (Windows)
 

--- a/BH/Constants.h
+++ b/BH/Constants.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define BH_VERSION "BH 1.9.8alpha3"
+#define BH_VERSION "BH 1.9.8alpha4"
 
 #define CODE_PAGE 1252 // windows-1252	ANSI Latin 1; Western European (Windows)
 

--- a/BH/Constants.h
+++ b/BH/Constants.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define BH_VERSION "BH 1.9.8alpha4"
+#define BH_VERSION "BH 1.9.8alpha5"
 
 #define CODE_PAGE 1252 // windows-1252	ANSI Latin 1; Western European (Windows)
 

--- a/BH/Constants.h
+++ b/BH/Constants.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define BH_VERSION "BH 1.9.8alpha"
+#define BH_VERSION "BH 1.9.8alpha2"
 
 #define CODE_PAGE 1252 // windows-1252	ANSI Latin 1; Western European (Windows)
 

--- a/BH/Constants.h
+++ b/BH/Constants.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define BH_VERSION "BH 1.9.7"
+#define BH_VERSION "BH 1.9.8alpha"
 
 #define CODE_PAGE 1252 // windows-1252	ANSI Latin 1; Western European (Windows)
 

--- a/BH/Drawing/UI/UI.cpp
+++ b/BH/Drawing/UI/UI.cpp
@@ -174,16 +174,20 @@ void UI::OnDraw() {
 	}
 }
 
-void UI::SetDragged(bool state) { 
+void UI::SetDragged(bool state, bool write_file) {
 	Lock(); 
 	dragged = state; 
-	if (!state) {
+	if (!state && write_file) {
 		WritePrivateProfileString(name.c_str(), "X", to_string<unsigned int>(GetX()).c_str(), string(BH::path + "UI.ini").c_str());
 		WritePrivateProfileString(name.c_str(), "Y", to_string<unsigned int>(GetY()).c_str(), string(BH::path + "UI.ini").c_str());
 		WritePrivateProfileString(name.c_str(), "minimizedX", to_string<unsigned int>(GetMinimizedX()).c_str(), string(BH::path + "UI.ini").c_str());
 		WritePrivateProfileString(name.c_str(), "minimizedY", to_string<unsigned int>(GetMinimizedY()).c_str(), string(BH::path + "UI.ini").c_str());
 	}
 	Unlock(); 
+}
+
+void UI::SetDragged(bool state) {
+    SetDragged(state, false);
 }
 
 void UI::SetMinimized(bool newState) { 
@@ -228,7 +232,7 @@ bool UI::OnLeftClick(bool up, unsigned int mouseX, unsigned int mouseY) {
 			}
 			else
 			{
-				SetDragged(false);
+				SetDragged(false, true);
 				if(!up) {
 					PrintText(7, "CTRL-click to open settings" );
 					PrintText(7, "Shift-drag to move" );
@@ -248,7 +252,7 @@ bool UI::OnLeftClick(bool up, unsigned int mouseX, unsigned int mouseY) {
 		} 
 		else
 		{
-			SetDragged(false);
+			SetDragged(false, true);
 			if( startX == mouseX && startY == mouseY && GetAsyncKeyState(VK_CONTROL) )
 			{
 				PrintText(135, "Right Click to Close" );
@@ -271,7 +275,7 @@ bool UI::OnLeftClick(bool up, unsigned int mouseX, unsigned int mouseY) {
 		return true;
 	}
 	SetActive(false);
-	SetDragged(false);
+	SetDragged(false, false);
 	return false;
 }
 

--- a/BH/Drawing/UI/UI.h
+++ b/BH/Drawing/UI/UI.h
@@ -55,7 +55,8 @@ namespace Drawing {
 			void SetActive(bool newState) { Lock(); active = newState; Unlock(); };
 			void SetMinimized(bool newState);
 			void SetName(std::string newName) { Lock(); name = newName;  Unlock(); };
-			void SetDragged(bool state);
+			void SetDragged(bool state, bool write_file); // only write config to file if write_file is true
+			void SetDragged(bool state); // never writes the config file
 			void SetZOrder(unsigned int newZ) { Lock(); zOrder = newZ; Unlock(); };
 
 			UITab* GetActiveTab() { if (!currentTab) { currentTab = (*Tabs.begin()); } return currentTab; };

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -50,6 +50,7 @@
 #include "../../D2Stubs.h"
 #include "ItemDisplay.h"
 #include "../../MPQInit.h"
+#include "lrucache.hpp"
 
 ItemsTxtStat* GetAllStatModifier(ItemsTxtStat* pStats, int nStats, int nStat, ItemsTxtStat* pOrigin);
 ItemsTxtStat* GetItemsTxtStatByMod(ItemsTxtStat* pStats, int nStats, int nStat, int nStatParam);
@@ -84,6 +85,14 @@ void Item::OnLoad() {
 		itemNamePatch->Install();
 
 	DrawSettings();
+}
+
+void Item::OnGameJoin() {
+	// reset the item name cache upon joining games
+	//if (!item_name_cache) { // for reproducing the incorrect caching bug (GUIDs not unique across games)
+		PrintText(1, "Reseting item name LRU cache.");
+		item_name_cache.reset(new cache::lru_cache<DWORD, pair<string,string>>(50));
+	//}
 }
 
 void Item::LoadConfig() {

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -90,8 +90,8 @@ void Item::OnLoad() {
 void Item::OnGameJoin() {
 	// reset the item name cache upon joining games
 	//if (!item_name_cache) { // for reproducing the incorrect caching bug (GUIDs not unique across games)
-		PrintText(1, "Reseting item name LRU cache.");
-		item_name_cache.reset(new cache::lru_cache<DWORD, pair<string,string>>(50));
+		//PrintText(1, "Reseting item name LRU cache.");
+		item_name_cache.ResetCache();
 	//}
 }
 

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -89,10 +89,9 @@ void Item::OnLoad() {
 
 void Item::OnGameJoin() {
 	// reset the item name cache upon joining games
-	//if (!item_name_cache) { // for reproducing the incorrect caching bug (GUIDs not unique across games)
-		//PrintText(1, "Reseting item name LRU cache.");
-		item_name_cache.ResetCache();
-	//}
+	// (GUIDs not unique across games)
+	item_name_cache.ResetCache();
+	map_action_cache.ResetCache();
 }
 
 void Item::LoadConfig() {

--- a/BH/Modules/Item/Item.h
+++ b/BH/Modules/Item/Item.h
@@ -67,6 +67,8 @@ class Item : public Module {
 		void LoadConfig();
 		void DrawSettings();
 
+		void OnGameJoin();
+
 		void OnLoop();
 		void OnKey(bool up, BYTE key, LPARAM lParam, bool* block);
 		void OnLeftClick(bool up, int x, int y, bool* block);

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -175,8 +175,27 @@ string ItemNameLookupCache::to_str(const string &name) {
 	return itemName;
 }
 
+vector<Action> MapActionLookupCache::make_cached_T(UnitItemInfo *uInfo) {
+	vector<Action> actions;
+	for (vector<Rule*>::const_iterator it = RuleList.begin(); it != RuleList.end(); it++) {
+		if ((*it)->Evaluate(uInfo, NULL)) {
+			actions.push_back((*it)->action);
+		}
+	}
+	return actions;
+}
+
+string MapActionLookupCache::to_str(const vector<Action> &actions) {
+	string name;
+	for (auto &action : actions) {
+		name += action.name + " ";
+	}
+	return name;
+}
+
 // least recently used cache for storing a limited number of item names
 ItemNameLookupCache item_name_cache(RuleList);
+MapActionLookupCache map_action_cache(MapRuleList);
 
 void GetItemName(UnitItemInfo *uInfo, string &name) {
 	string new_name = item_name_cache.Get(uInfo, name);
@@ -355,6 +374,7 @@ namespace ItemDisplay {
 		item_display_initialized = true;
 		rules.clear();
 		item_name_cache.ResetCache();
+		map_action_cache.ResetCache();
 		BH::config->ReadMapList("ItemDisplay", rules);
 		for (unsigned int i = 0; i < rules.size(); i++) {
 			string buf;
@@ -388,6 +408,7 @@ namespace ItemDisplay {
 	void UninitializeItemRules() {
 		item_display_initialized = false;
 		item_name_cache.ResetCache();
+		map_action_cache.ResetCache();
 		RuleList.clear();
 		MapRuleList.clear();
 		IgnoreRuleList.clear();

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -344,6 +344,7 @@ namespace ItemDisplay {
 
 		item_display_initialized = true;
 		rules.clear();
+		item_name_cache.ResetCache();
 		BH::config->ReadMapList("ItemDisplay", rules);
 		for (unsigned int i = 0; i < rules.size(); i++) {
 			string buf;
@@ -376,6 +377,7 @@ namespace ItemDisplay {
 
 	void UninitializeItemRules() {
 		item_display_initialized = false;
+		item_name_cache.ResetCache();
 		RuleList.clear();
 		MapRuleList.clear();
 		IgnoreRuleList.clear();

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -343,13 +343,11 @@ namespace ItemDisplay {
 			}
 
 			LastConditionType = CT_None;
-			Rule *r = new Rule();
 			vector<Condition*> RawConditions;
 			for (vector<string>::iterator tok = tokens.begin(); tok < tokens.end(); tok++) {
 				Condition::BuildConditions(RawConditions, (*tok));
 			}
-			Condition::ProcessConditions(RawConditions, r->conditions);
-			BuildAction(&(rules[i].second), &(r->action));
+			Rule *r = new Rule(RawConditions, &(rules[i].second));
 
 			RuleList.push_back(r);
 			if (r->action.colorOnMap != UNDEFINED_COLOR ||
@@ -371,6 +369,12 @@ namespace ItemDisplay {
 		MapRuleList.clear();
 		IgnoreRuleList.clear();
 	}
+}
+
+Rule::Rule(vector<Condition*> &inputConditions, string *str) {
+	Condition::ProcessConditions(inputConditions, conditions);
+	BuildAction(str, &action);
+	conditionStack.reserve(conditions.size()); // TODO: too large?
 }
 
 void BuildAction(string *str, Action *act) {

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -406,6 +406,16 @@ namespace ItemDisplay {
 	}
 
 	void UninitializeItemRules() {
+		// RuleList contains every created rule. MapRuleList and IgnoreRuleList have a subset of rules.
+		// Deleting objects in RuleList is sufficient.
+		if (item_display_initialized) {
+			for (Rule *r : RuleList) {
+				for (Condition *condition : r->conditions) {
+					delete condition;
+				}
+				delete r;
+			}
+		}
 		item_display_initialized = false;
 		item_name_cache.ResetCache();
 		map_action_cache.ResetCache();

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -165,6 +165,16 @@ string ItemNameLookupCache::make_cached_T(UnitItemInfo *uInfo, const string &nam
 	return new_name;
 }
 
+string ItemNameLookupCache::to_str(const string &name) {
+	size_t start_pos = 0;
+	std::string itemName(name);
+	while ((start_pos = itemName.find('\n', start_pos)) != std::string::npos) {
+		itemName.replace(start_pos, 1, " - ");
+		start_pos += 3;
+	}
+	return itemName;
+}
+
 // least recently used cache for storing a limited number of item names
 ItemNameLookupCache item_name_cache(RuleList);
 

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -151,14 +151,56 @@ BYTE RuneNumberFromItemCode(char *code){
 	return (BYTE)(((code[1] - '0') * 10) + code[2] - '0');
 }
 
+// least recently used cache for storing a limited number of item names
+unique_ptr<cache::lru_cache<DWORD, pair<string, string>>> item_name_cache;
+
 void GetItemName(UnitItemInfo *uInfo, string &name) {
-	for (vector<Rule*>::iterator it = RuleList.begin(); it != RuleList.end(); it++) {
-		if ((*it)->Evaluate(uInfo, NULL)) {
-			SubstituteNameVariables(uInfo, name, &(*it)->action);
-			if ((*it)->action.stopProcessing) {
-				break;
+	// set to true to print when mismatch occurs (will never use cached name in this case)
+	constexpr bool item_name_cache_debug = false;
+	static DWORD last_printed_guid = 0; // to prevent excessive printing
+	// TODO: report error if item_name_cache never initialized (should be done in onGameJoin)
+	DWORD guid = uInfo->item->dwUnitId; // global unique identifier
+	const string name_cpy(name); // used to store the original item name which is edited in place
+	string orig_cached_name; // the cached unmodified item name
+	string cached_name; // the cached item name after rules applied
+	bool cache_hit = false;
+	// First check if the name exists in the cache
+	if (item_name_cache && item_name_cache->exists(guid)) {
+		orig_cached_name.assign(item_name_cache->get(guid).first);
+		if (orig_cached_name == name) {
+			cached_name.assign(item_name_cache->get(guid).second);
+			cache_hit = true; // needed because empty string is also a valid item name
+		} else {
+			// This print can tell you if a GUID ever changes for an item. Problem is that it will also
+			// print whenever you ID an item, make a runeword, personalize an item, etc.
+			// I suggest we leave it on for awhile to make sure GUIDs are never changing on us. -ybd
+			PrintText(1, "Detected change in unmodified item name. Cached: %s Actual: %s", orig_cached_name.c_str(), name.c_str());
+		}
+		// cache_hit is false if the unmodified item name has changed from cached version
+	}
+	if (!cache_hit || item_name_cache_debug) {
+		for (vector<Rule*>::iterator it = RuleList.begin(); it != RuleList.end(); it++) {
+			if ((*it)->Evaluate(uInfo, NULL)) {
+				SubstituteNameVariables(uInfo, name, &(*it)->action);
+				if ((*it)->action.stopProcessing) {
+					break;
+				}
 			}
 		}
+		if (item_name_cache && !cache_hit) {
+			pair<string, string> pair_to_cache(name_cpy, name);
+			item_name_cache->put(guid, pair_to_cache);
+			//PrintText(1, "Adding key value pair %u, %s to cache.", guid, name.c_str());
+		}
+		else if (cached_name != name) {
+			// only runs if item_name_debug is on
+			if (guid != last_printed_guid) {
+				PrintText(1, "Mismatch in modified item name! Cached: %s Actual: %s", cached_name.c_str(), name.c_str());
+				last_printed_guid = guid;
+			}
+		}
+	} else {
+		name.assign(cached_name);
 	}
 }
 

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -584,11 +584,19 @@ class ItemNameLookupCache : public RuleLookupCache<string, const string &> {
 	using RuleLookupCache::RuleLookupCache;
 };
 
+class MapActionLookupCache : public RuleLookupCache<vector<Action>> {
+	vector<Action> make_cached_T(UnitItemInfo *uInfo) override;
+	string to_str(const vector<Action> &actions);
+
+	using RuleLookupCache::RuleLookupCache;
+};
+
 extern vector<Rule*> RuleList;
 extern vector<Rule*> MapRuleList;
 extern vector<Rule*> IgnoreRuleList;
 extern vector<pair<string, string>> rules;
 extern ItemNameLookupCache item_name_cache;
+extern MapActionLookupCache map_action_cache;
 
 namespace ItemDisplay {
 	void InitializeItemRules();

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -6,7 +6,7 @@
 #include "../../BH.h"
 #include <cstdlib>
 #include <regex>
-#include "lrucache.hpp"
+#include "../../RuleLookupCache.h"
 
 #define EXCEPTION_INVALID_STAT			1
 #define EXCEPTION_INVALID_OPERATION		2
@@ -577,13 +577,17 @@ struct Rule {
 	}
 };
 
+class ItemNameLookupCache : public RuleLookupCache<string> {
+    string make_cached_T(UnitItemInfo *uInfo, const string &name) override;
+
+    using RuleLookupCache::RuleLookupCache;
+};
+
 extern vector<Rule*> RuleList;
 extern vector<Rule*> MapRuleList;
 extern vector<Rule*> IgnoreRuleList;
 extern vector<pair<string, string>> rules;
-// TODO: This should probably be encapsulated somehow to protect access, but
-//       I don't want to mess with the architecture too much.
-extern unique_ptr<cache::lru_cache<DWORD, pair<string,string>>> item_name_cache;
+extern ItemNameLookupCache item_name_cache;
 
 namespace ItemDisplay {
 	void InitializeItemRules();

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -6,6 +6,7 @@
 #include "../../BH.h"
 #include <cstdlib>
 #include <regex>
+#include "lrucache.hpp"
 
 #define EXCEPTION_INVALID_STAT			1
 #define EXCEPTION_INVALID_OPERATION		2
@@ -580,6 +581,9 @@ extern vector<Rule*> RuleList;
 extern vector<Rule*> MapRuleList;
 extern vector<Rule*> IgnoreRuleList;
 extern vector<pair<string, string>> rules;
+// TODO: This should probably be encapsulated somehow to protect access, but
+//       I don't want to mess with the architecture too much.
+extern unique_ptr<cache::lru_cache<DWORD, pair<string,string>>> item_name_cache;
 
 namespace ItemDisplay {
 	void InitializeItemRules();

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -577,10 +577,11 @@ struct Rule {
 	}
 };
 
-class ItemNameLookupCache : public RuleLookupCache<string> {
-    string make_cached_T(UnitItemInfo *uInfo, const string &name) override;
+class ItemNameLookupCache : public RuleLookupCache<string, const string &> {
+	string make_cached_T(UnitItemInfo *uInfo, const string &name) override;
+	string to_str(const string &name) override;
 
-    using RuleLookupCache::RuleLookupCache;
+	using RuleLookupCache::RuleLookupCache;
 };
 
 extern vector<Rule*> RuleList;

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -520,7 +520,11 @@ struct Action {
 struct Rule {
 	vector<Condition*> conditions;
 	Action action;
+	vector<Condition*> conditionStack;
 
+	Rule(vector<Condition*> &inputConditions, string *str);
+
+	// TODO: Should this really be defined in the header? This will force it to be inlined AFAIK. -ybd
 	// Evaluate conditions which are in Reverse Polish Notation
 	bool Evaluate(UnitItemInfo *uInfo, ItemInfo *info) {
 		if (conditions.size() == 0) {
@@ -529,7 +533,12 @@ struct Rule {
 
 		bool retval;
 		try {
-			vector<Condition*> conditionStack;
+			// conditionStack was previously declared on the stack within this function. This caused
+			// excessive allocaiton calls and was limiting the speed of the item display (causing
+			// frame rate drops with complex item displays while ALT was held down). Moving this vector
+			// to the object level, preallocating size, and using the resize(0) method to clear avoids
+			// excessive reallocation.
+			conditionStack.resize(0); 
 			for (unsigned int i = 0; i < conditions.size(); i++) {
 				Condition *input = conditions[i];
 				if (input->conditionType == CT_Operand) {

--- a/BH/Modules/Maphack/Maphack.cpp
+++ b/BH/Modules/Maphack/Maphack.cpp
@@ -512,32 +512,31 @@ void Maphack::OnAutomapDraw() {
 					uInfo.itemCode[3] = 0;
 					if (ItemAttributeMap.find(uInfo.itemCode) != ItemAttributeMap.end()) {
 						uInfo.attrs = ItemAttributeMap[uInfo.itemCode];
-						for (vector<Rule*>::iterator it = MapRuleList.begin(); it != MapRuleList.end(); it++) {
-							if ((*it)->Evaluate(&uInfo, NULL)) {
-								auto color = (*it)->action.colorOnMap;
-								auto borderColor = (*it)->action.borderColor;
-								auto dotColor = (*it)->action.dotColor;
-								auto pxColor = (*it)->action.pxColor;
-								auto lineColor = (*it)->action.lineColor;
-								xPos = unit->pItemPath->dwPosX;
-								yPos = unit->pItemPath->dwPosY;
-								automapBuffer.push_top_layer(
-										[color, unit, xPos, yPos, MyPos, borderColor, dotColor, pxColor, lineColor]()->void{
-									POINT automapLoc;
-									Drawing::Hook::ScreenToAutomap(&automapLoc, xPos, yPos);
-									if (borderColor != UNDEFINED_COLOR)
-										Drawing::Boxhook::Draw(automapLoc.x - 4, automapLoc.y - 4, 8, 8, borderColor, Drawing::BTHighlight);
-									if (color != UNDEFINED_COLOR)
-										Drawing::Boxhook::Draw(automapLoc.x - 3, automapLoc.y - 3, 6, 6, color, Drawing::BTHighlight);
-									if (dotColor != UNDEFINED_COLOR)
-										Drawing::Boxhook::Draw(automapLoc.x - 2, automapLoc.y - 2, 4, 4, dotColor, Drawing::BTHighlight);
-									if (pxColor != UNDEFINED_COLOR)
-										Drawing::Boxhook::Draw(automapLoc.x - 1, automapLoc.y - 1, 2, 2, pxColor, Drawing::BTHighlight);
-									if (lineColor != UNDEFINED_COLOR) {
-										Drawing::Linehook::Draw(MyPos.x, MyPos.y, automapLoc.x, automapLoc.y, lineColor);
-									}
-								});
-							}
+						const vector<Action> actions = map_action_cache.Get(&uInfo);
+						for (auto &action : actions) {
+							auto color = action.colorOnMap;
+							auto borderColor = action.borderColor;
+							auto dotColor = action.dotColor;
+							auto pxColor = action.pxColor;
+							auto lineColor = action.lineColor;
+							xPos = unit->pItemPath->dwPosX;
+							yPos = unit->pItemPath->dwPosY;
+							automapBuffer.push_top_layer(
+									[color, unit, xPos, yPos, MyPos, borderColor, dotColor, pxColor, lineColor]()->void{
+								POINT automapLoc;
+								Drawing::Hook::ScreenToAutomap(&automapLoc, xPos, yPos);
+								if (borderColor != UNDEFINED_COLOR)
+									Drawing::Boxhook::Draw(automapLoc.x - 4, automapLoc.y - 4, 8, 8, borderColor, Drawing::BTHighlight);
+								if (color != UNDEFINED_COLOR)
+									Drawing::Boxhook::Draw(automapLoc.x - 3, automapLoc.y - 3, 6, 6, color, Drawing::BTHighlight);
+								if (dotColor != UNDEFINED_COLOR)
+									Drawing::Boxhook::Draw(automapLoc.x - 2, automapLoc.y - 2, 4, 4, dotColor, Drawing::BTHighlight);
+								if (pxColor != UNDEFINED_COLOR)
+									Drawing::Boxhook::Draw(automapLoc.x - 1, automapLoc.y - 1, 2, 2, pxColor, Drawing::BTHighlight);
+								if (lineColor != UNDEFINED_COLOR) {
+									Drawing::Linehook::Draw(MyPos.x, MyPos.y, automapLoc.x, automapLoc.y, lineColor);
+								}
+							});
 						}
 					}
 					else {

--- a/BH/Modules/Party/Party.cpp
+++ b/BH/Modules/Party/Party.cpp
@@ -127,7 +127,7 @@ void Party::CheckParty() {
 			}
 		}
 		if (min_party_id_valid && !master_party_exists) {
-			PrintText(1, "Master party disbanded. Resetting min_party_id.");
+			//PrintText(1, "Master party disbanded. Resetting min_party_id.");
 			min_party_id_valid = false;
 			min_party_id = 0xFFFF;
 			c++;

--- a/BH/Modules/Party/Party.cpp
+++ b/BH/Modules/Party/Party.cpp
@@ -63,7 +63,7 @@ void Party::CheckParty() {
 			if(!_stricmp(Party->szName, MyRoster->szName))
 				continue;
 			if(!Party->wLevel) {
-				PrintText(1, "!Party->wLevel");
+				//PrintText(1, "!Party->wLevel");
 				c++;
 				return;
 			}
@@ -93,7 +93,7 @@ void Party::CheckParty() {
 				if (Toggles["LootEnabled"].state) {
 					string s(Party->szName);
 					if (LootingPermission.find(s) == LootingPermission.end()) {
-						PrintText(1, "Enabling loot for %s.", s.c_str());
+						//PrintText(1, "Enabling loot for %s.", s.c_str());
 						BYTE PacketData[7] = {0x5d,1,1,0,0,0,0};
 						*reinterpret_cast<int*>(PacketData + 3) = Party->dwUnitId;
 						D2NET_SendPacket(7, 1, PacketData);
@@ -107,13 +107,13 @@ void Party::CheckParty() {
 				if(Party->dwPartyFlags & PARTY_INVITED_YOU) {
 					if (current_min_party_id != INVALID_PARTY_ID) {
 						if (Party->wPartyId == current_min_party_id) {
-							PrintText(1, "Found the right party");
+							//PrintText(1, "Found the right party");
 							D2CLIENT_ClickParty(Party, 2);
 							c++;
 							return;
 						}
 					} else {
-						PrintText(1, "PARTY_INVITED_YOU, clicking party");
+						//PrintText(1, "PARTY_INVITED_YOU, clicking party");
 						D2CLIENT_ClickParty(Party, 2);
 						c++;
 						return;
@@ -127,13 +127,13 @@ void Party::CheckParty() {
 					}
 					if (current_min_party_id != INVALID_PARTY_ID) {
 						if (MyRoster->wPartyId == current_min_party_id) {
-							PrintText(1, "I'm in the right party, inviting another.");
+							//PrintText(1, "I'm in the right party, inviting another.");
 							D2CLIENT_ClickParty(Party, 2);
 							c++;
 							return;
 						}
 					} else {
-						PrintText(1, "There's no master party, trying to form one.");
+						//PrintText(1, "There's no master party, trying to form one.");
 						D2CLIENT_ClickParty(Party, 2);
 						c++;
 						return;
@@ -145,16 +145,16 @@ void Party::CheckParty() {
 		// Leave the party if we're in the wrong one
 		if (Toggles["Enabled"].state && current_min_party_id != INVALID_PARTY_ID 
 			&& MyRoster->wPartyId != current_min_party_id && MyRoster->wPartyId != INVALID_PARTY_ID) {
-			PrintText(1, "Not in the right party!");
-			PrintText(1, "min_party_id=%hu, MyRoster->wPartyId=%hu", current_min_party_id, MyRoster->wPartyId);
+			//PrintText(1, "Not in the right party!");
+			//PrintText(1, "min_party_id=%hu, MyRoster->wPartyId=%hu", current_min_party_id, MyRoster->wPartyId);
 			D2CLIENT_LeaveParty();
 			c++;
 			return;
 		}
-		// Remove looting permissions for players no longer in the game??
+		// Remove looting permissions for players no longer in the game
 		for (auto it = LootingPermission.cbegin(); it != LootingPermission.cend(); ) {
 			if (CurrentParty.find((*it).first) == CurrentParty.end()) {
-				PrintText(1, "Removing %s from looting map.", ((*it).first).c_str());
+				//PrintText(1, "Removing %s from looting map.", ((*it).first).c_str());
 				LootingPermission.erase(it++);
 			} else {
 				++it;

--- a/BH/Modules/Party/Party.cpp
+++ b/BH/Modules/Party/Party.cpp
@@ -98,28 +98,28 @@ void Party::CheckParty() {
 				if (Party->wPartyId == min_party_id) master_party_exists = true;
 			}
 			if ((Party->wPartyId == INVALID_PARTY_ID || Party->wPartyId != MyRoster->wPartyId) && Toggles["Enabled"].state) {
-				PrintText(1, "Party->wPartyID=%hu, MyRoster->wPartyId=%hu, min_party_id=%hu, min_party_id_valid=%hu", 
-						Party->wPartyId, MyRoster->wPartyId, min_party_id, (WORD)(min_party_id_valid));
+				//PrintText(1, "Party->wPartyID=%hu, MyRoster->wPartyId=%hu, min_party_id=%hu, min_party_id_valid=%hu", 
+						//Party->wPartyId, MyRoster->wPartyId, min_party_id, (WORD)(min_party_id_valid));
 				if(Party->dwPartyFlags & PARTY_INVITED_YOU) {
 					if (min_party_id_valid) {
 						if (Party->wPartyId == min_party_id) {
-							PrintText(1, "Found the right party");
+							//PrintText(1, "Found the right party");
 							D2CLIENT_ClickParty(Party, 2);
 						}
 					} else {
-						PrintText(1, "PARTY_INVITED_YOU, clicking party");
+						//PrintText(1, "PARTY_INVITED_YOU, clicking party");
 						D2CLIENT_ClickParty(Party, 2);
 					}
 					c++;
 					return;
 				}
 				if(Party->wPartyId == INVALID_PARTY_ID) {
-					PrintText(1, "INVALID_PARTY_ID");
+					//PrintText(1, "INVALID_PARTY_ID");
 					if(Party->dwPartyFlags & PARTY_INVITED_BY_YOU) {
-						PrintText(1, "PARTY_INVITED_BY_YOU");
+						//PrintText(1, "PARTY_INVITED_BY_YOU");
 						continue;
 					}
-					PrintText(1, "Clicking Party");
+					//PrintText(1, "Clicking Party");
 					D2CLIENT_ClickParty(Party, 2);
 					c++;
 					return;
@@ -135,8 +135,8 @@ void Party::CheckParty() {
 		}
 		min_party_id_valid = local_min_party_id_valid;
 		if (Toggles["Enabled"].state && min_party_id_valid && MyRoster->wPartyId != min_party_id) {
-			PrintText(1, "Not in the right party!");
-			PrintText(1, "min_party_id=%hu, MyRoster->wPartyId=%hu", min_party_id, MyRoster->wPartyId);
+			//PrintText(1, "Not in the right party!");
+			//PrintText(1, "min_party_id=%hu, MyRoster->wPartyId=%hu", min_party_id, MyRoster->wPartyId);
 			D2CLIENT_LeaveParty();
 			c++;
 			return;

--- a/BH/Modules/Party/Party.cpp
+++ b/BH/Modules/Party/Party.cpp
@@ -21,8 +21,6 @@ void Party::OnLoad() {
 }
 
 void Party::OnGameJoin() {
-	min_party_id = 0xFFFF;
-	min_party_id_valid = false;
 }
 
 void Party::OnUnload() {
@@ -56,9 +54,6 @@ void Party::CheckParty() {
 		UnitAny* Me = *p_D2CLIENT_PlayerUnit;
 		RosterUnit* MyRoster = FindPlayerRoster(Me->dwUnitId);
 		BnetData* pData = (*p_D2LAUNCH_BnData);
-
-		//bool local_min_party_id_valid = true;
-		//bool master_party_exists = false;
 
 		WORD current_min_party_id = 0xFFFF;
 
@@ -98,6 +93,7 @@ void Party::CheckParty() {
 				if (Toggles["LootEnabled"].state) {
 					string s(Party->szName);
 					if (LootingPermission.find(s) == LootingPermission.end()) {
+						PrintText(1, "Enabling loot for %s.", s.c_str());
 						BYTE PacketData[7] = {0x5d,1,1,0,0,0,0};
 						*reinterpret_cast<int*>(PacketData + 3) = Party->dwUnitId;
 						D2NET_SendPacket(7, 1, PacketData);
@@ -158,6 +154,7 @@ void Party::CheckParty() {
 		// Remove looting permissions for players no longer in the game??
 		for (auto it = LootingPermission.cbegin(); it != LootingPermission.cend(); ) {
 			if (CurrentParty.find((*it).first) == CurrentParty.end()) {
+				PrintText(1, "Removing %s from looting map.", ((*it).first).c_str());
 				LootingPermission.erase(it++);
 			} else {
 				++it;

--- a/BH/Modules/Party/Party.h
+++ b/BH/Modules/Party/Party.h
@@ -14,11 +14,14 @@ class Party : public Module {
 		map<std::string, bool> LootingPermission;
 		void CheckParty();
 		int c;
+		WORD min_party_id;
+		bool min_party_id_valid;
 	public:
-		Party() : Module("Party") {};
+		Party() : Module("Party"), min_party_id(0xFFFF), min_party_id_valid(false) {};
 		void OnLoad();
 		void OnUnload();
 		void OnLoop();
 		void OnKey(bool up, BYTE key, LPARAM lParam, bool* block);
 		void OnGameExit();
+		void OnGameJoin();
 };

--- a/BH/Modules/Party/Party.h
+++ b/BH/Modules/Party/Party.h
@@ -14,10 +14,8 @@ class Party : public Module {
 		map<std::string, bool> LootingPermission;
 		void CheckParty();
 		int c;
-		WORD min_party_id;
-		bool min_party_id_valid;
 	public:
-		Party() : Module("Party"), min_party_id(0xFFFF), min_party_id_valid(false) {};
+		Party() : Module("Party") {};
 		void OnLoad();
 		void OnUnload();
 		void OnLoop();

--- a/BH/RuleLookupCache.h
+++ b/BH/RuleLookupCache.h
@@ -25,11 +25,11 @@ class RuleLookupCache {
 
 	public:
 	RuleLookupCache(const std::vector<Rule*> &rule_list) 
-		: RuleList(rule_list), cache(new cache::lru_cache<DWORD, std::pair<DWORD, T>>(50)) {}
+		: RuleList(rule_list), cache(new cache::lru_cache<DWORD, std::pair<DWORD, T>>(100)) {}
 
 	void ResetCache() {
 		//PrintText(1, "Reseting LRU cache.");
-		cache.reset(new cache::lru_cache<DWORD, std::pair<DWORD, T>>(50));
+		cache.reset(new cache::lru_cache<DWORD, std::pair<DWORD, T>>(100));
 	}
 	
 	// TODO: UnitItemInfo should probably be const, but call to Evaluate needs non-const

--- a/BH/RuleLookupCache.h
+++ b/BH/RuleLookupCache.h
@@ -38,7 +38,10 @@ class RuleLookupCache {
 		constexpr bool cache_debug = false;
 		static DWORD last_printed_guid = 0; // to prevent excessive printing
 		DWORD guid = uInfo->item->dwUnitId; // global unique identifier
-		// TODO: should we also use fingerprint or seed?
+		// TODO: should we also use fingerprint or seed? Currently we trigger cache updates based
+		// on item flag changes. This should cover everything that I can think of, including IDing
+		// items, crafting items, making runewords, etc. Still would be nice to get some reassurance
+		// that GUIDs aren't reused in some unexpected way. Having a cache that is wrong is no bueno.
 		DWORD flags = uInfo->item->pItemData->dwFlags;
 		DWORD orig_cached_flags; // the cached flags
 		T cached_T; // the cached T after rules applied
@@ -52,9 +55,9 @@ class RuleLookupCache {
 			} else {
 				// This print can give a hint if the GUID of an item ever changes. Problem is that it will also
 				// print whenever you ID an item, make a runeword, personalize an item, etc.
-				// I suggest we leave it on for awhile to make sure GUIDs are never changing on us. -ybd
-				PrintText(1, "Detected change in item flags. Cached: %x Actual: %x", orig_cached_flags, flags);
-				PrintText(1, "    Cached name str: %s", to_str(cache->get(guid).second).c_str());
+				// Even seems to change when items get 'old'.
+				//PrintText(1, "Detected change in item flags. Cached: %x Actual: %x", orig_cached_flags, flags);
+				//PrintText(1, "    Cached name str: %s", to_str(cache->get(guid).second).c_str());
 			}
 			// cache_hit is false if the unmodified item name has changed from cached version
 		}

--- a/BH/RuleLookupCache.h
+++ b/BH/RuleLookupCache.h
@@ -11,56 +11,59 @@ extern struct Rule;
 #include <utility>
 #include "lrucache.hpp"
 
-template <typename T>
+template <typename T, typename... Args>
 class RuleLookupCache {
-	std::unique_ptr<cache::lru_cache<DWORD, std::pair<std::string, T>>> cache;
+	std::unique_ptr<cache::lru_cache<DWORD, std::pair<DWORD, T>>> cache;
 	
 	protected:
 	const std::vector<Rule*> &RuleList;
-	virtual T make_cached_T(UnitItemInfo *uInfo, const string &name) = 0;
+	virtual T make_cached_T(UnitItemInfo *uInfo, Args&&... pack) = 0;
+	virtual std::string to_str(const T &cached_T) {
+		// This function only needs to be implemented for debug printing
+		return std::string("???");
+	}
 
 	public:
 	RuleLookupCache(const std::vector<Rule*> &rule_list) 
-		: RuleList(rule_list), cache(new cache::lru_cache<DWORD, std::pair<std::string, T>>(50)) {}
+		: RuleList(rule_list), cache(new cache::lru_cache<DWORD, std::pair<DWORD, T>>(50)) {}
 
 	void ResetCache() {
-		cache.reset(new cache::lru_cache<DWORD, std::pair<std::string, T>>(50));
+		cache.reset(new cache::lru_cache<DWORD, std::pair<DWORD, T>>(50));
 	}
 	
 	// TODO: UnitItemInfo should probably be const, but call to Evaluate needs non-const
-	T Get(UnitItemInfo *uInfo, const std::string &name) {
-		// set to true to print when mismatch occurs (will never use cached name in this case)
+	T Get(UnitItemInfo *uInfo, Args&&... pack) {
+		// leave this false. doesn't work 
 		constexpr bool cache_debug = false;
 		static DWORD last_printed_guid = 0; // to prevent excessive printing
-		// TODO: report error if cache never initialized (should be done in onGameJoin)
 		DWORD guid = uInfo->item->dwUnitId; // global unique identifier
-		//const string name_cpy(name); // used to store the original item name which is edited in place
-		std::string orig_cached_name; // the cached unmodified item name
-		T cached_T; // the cached item name after rules applied
+		// TODO: should we also use fingerprint or seed?
+		DWORD flags = uInfo->item->pItemData->dwFlags;
+		DWORD orig_cached_flags; // the cached flags
+		T cached_T; // the cached T after rules applied
 		bool cache_hit = false;
 		// First check if the name exists in the cache
 		if (cache && cache->exists(guid)) {
-			orig_cached_name.assign(cache->get(guid).first);
-			if (orig_cached_name == name) {
-				//cached_name.assign(cache->get(guid).second);
+			orig_cached_flags = cache->get(guid).first;
+			if (orig_cached_flags == flags) {
 				cached_T = cache->get(guid).second;
 				cache_hit = true; // needed because empty string is also a valid item name
 			} else {
-				// This print can tell you if a GUID ever changes for an item. Problem is that it will also
+				// This print can give a hint if the GUID of an item ever changes. Problem is that it will also
 				// print whenever you ID an item, make a runeword, personalize an item, etc.
 				// I suggest we leave it on for awhile to make sure GUIDs are never changing on us. -ybd
-				PrintText(1, "Detected change in unmodified item name. Cached: %s Actual: %s", orig_cached_name.c_str(), name.c_str());
+				PrintText(1, "Detected change in item flags. Cached: %x Actual: %x", orig_cached_flags, flags);
 			}
 			// cache_hit is false if the unmodified item name has changed from cached version
 		}
 		if (!cache_hit || cache_debug) {
-			cached_T = make_cached_T(uInfo, name);
+			cached_T = make_cached_T(uInfo, pack...);
 			if (cache && !cache_hit) {
-				std::pair<std::string, T> pair_to_cache(name, cached_T);
+				std::pair<DWORD, T> pair_to_cache(flags, cached_T);
 				cache->put(guid, pair_to_cache);
-				//PrintText(1, "Adding key value pair %u, %s to cache.", guid, name.c_str());
+				//PrintText(1, "Adding key value pair %u, (%s, %x) to cache.", guid, to_str(cached_T).c_str(), flags);
 			}
-			// Debug stuff below doesn't work if T is not a string.
+			// Debug stuff below doesn't work anymore because there's no general comparison function implemented
 			//else if (cached_name != name) {
 				// only runs if item_name_debug is on
 			//	if (guid != last_printed_guid) {

--- a/BH/RuleLookupCache.h
+++ b/BH/RuleLookupCache.h
@@ -28,6 +28,7 @@ class RuleLookupCache {
 		: RuleList(rule_list), cache(new cache::lru_cache<DWORD, std::pair<DWORD, T>>(50)) {}
 
 	void ResetCache() {
+		//PrintText(1, "Reseting LRU cache.");
 		cache.reset(new cache::lru_cache<DWORD, std::pair<DWORD, T>>(50));
 	}
 	
@@ -53,6 +54,7 @@ class RuleLookupCache {
 				// print whenever you ID an item, make a runeword, personalize an item, etc.
 				// I suggest we leave it on for awhile to make sure GUIDs are never changing on us. -ybd
 				PrintText(1, "Detected change in item flags. Cached: %x Actual: %x", orig_cached_flags, flags);
+				PrintText(1, "    Cached name str: %s", to_str(cache->get(guid).second).c_str());
 			}
 			// cache_hit is false if the unmodified item name has changed from cached version
 		}

--- a/BH/RuleLookupCache.h
+++ b/BH/RuleLookupCache.h
@@ -54,21 +54,13 @@ class RuleLookupCache {
 			// cache_hit is false if the unmodified item name has changed from cached version
 		}
 		if (!cache_hit || cache_debug) {
-			//for (vector<Rule*>::const_iterator it = RuleList.begin(); it != RuleList.end(); it++) {
-			//	if ((*it)->Evaluate(uInfo, NULL)) {
-					cached_T = make_cached_T(uInfo, name);
-					//SubstituteNameVariables(uInfo, name, &(*it)->action);
-					//if ((*it)->action.stopProcessing) {
-					//	break;
-					//}
-					// make cached_T
-			//	}
-			//}
+			cached_T = make_cached_T(uInfo, name);
 			if (cache && !cache_hit) {
 				std::pair<std::string, T> pair_to_cache(name, cached_T);
 				cache->put(guid, pair_to_cache);
 				//PrintText(1, "Adding key value pair %u, %s to cache.", guid, name.c_str());
 			}
+			// Debug stuff below doesn't work if T is not a string.
 			//else if (cached_name != name) {
 				// only runs if item_name_debug is on
 			//	if (guid != last_printed_guid) {
@@ -77,7 +69,6 @@ class RuleLookupCache {
 			//	}
 			//}
 		} else {
-			//name.assign(cached_name);
 			return cached_T;
 		}
 			

--- a/BH/RuleLookupCache.h
+++ b/BH/RuleLookupCache.h
@@ -1,0 +1,87 @@
+// A cache wrapper class useful for inserting caches around rule list lookups
+
+#ifndef RULE_LOOKUP_CACHE_H_
+#define RULE_LOOKUP_CACHE_H_
+
+extern struct UnitItemInfo;
+extern struct Rule;
+
+#include <memory>
+#include <vector>
+#include <utility>
+#include "lrucache.hpp"
+
+template <typename T>
+class RuleLookupCache {
+	std::unique_ptr<cache::lru_cache<DWORD, std::pair<std::string, T>>> cache;
+	
+	protected:
+	const std::vector<Rule*> &RuleList;
+	virtual T make_cached_T(UnitItemInfo *uInfo, const string &name) = 0;
+
+	public:
+	RuleLookupCache(const std::vector<Rule*> &rule_list) 
+		: RuleList(rule_list), cache(new cache::lru_cache<DWORD, std::pair<std::string, T>>(50)) {}
+
+	void ResetCache() {
+		cache.reset(new cache::lru_cache<DWORD, std::pair<std::string, T>>(50));
+	}
+	
+	// TODO: UnitItemInfo should probably be const, but call to Evaluate needs non-const
+	T Get(UnitItemInfo *uInfo, const std::string &name) {
+		// set to true to print when mismatch occurs (will never use cached name in this case)
+		constexpr bool cache_debug = false;
+		static DWORD last_printed_guid = 0; // to prevent excessive printing
+		// TODO: report error if cache never initialized (should be done in onGameJoin)
+		DWORD guid = uInfo->item->dwUnitId; // global unique identifier
+		//const string name_cpy(name); // used to store the original item name which is edited in place
+		std::string orig_cached_name; // the cached unmodified item name
+		T cached_T; // the cached item name after rules applied
+		bool cache_hit = false;
+		// First check if the name exists in the cache
+		if (cache && cache->exists(guid)) {
+			orig_cached_name.assign(cache->get(guid).first);
+			if (orig_cached_name == name) {
+				//cached_name.assign(cache->get(guid).second);
+				cached_T = cache->get(guid).second;
+				cache_hit = true; // needed because empty string is also a valid item name
+			} else {
+				// This print can tell you if a GUID ever changes for an item. Problem is that it will also
+				// print whenever you ID an item, make a runeword, personalize an item, etc.
+				// I suggest we leave it on for awhile to make sure GUIDs are never changing on us. -ybd
+				PrintText(1, "Detected change in unmodified item name. Cached: %s Actual: %s", orig_cached_name.c_str(), name.c_str());
+			}
+			// cache_hit is false if the unmodified item name has changed from cached version
+		}
+		if (!cache_hit || cache_debug) {
+			//for (vector<Rule*>::const_iterator it = RuleList.begin(); it != RuleList.end(); it++) {
+			//	if ((*it)->Evaluate(uInfo, NULL)) {
+					cached_T = make_cached_T(uInfo, name);
+					//SubstituteNameVariables(uInfo, name, &(*it)->action);
+					//if ((*it)->action.stopProcessing) {
+					//	break;
+					//}
+					// make cached_T
+			//	}
+			//}
+			if (cache && !cache_hit) {
+				std::pair<std::string, T> pair_to_cache(name, cached_T);
+				cache->put(guid, pair_to_cache);
+				//PrintText(1, "Adding key value pair %u, %s to cache.", guid, name.c_str());
+			}
+			//else if (cached_name != name) {
+				// only runs if item_name_debug is on
+			//	if (guid != last_printed_guid) {
+			//		PrintText(1, "Mismatch in modified item name! Cached: %s Actual: %s", cached_name.c_str(), name.c_str());
+			//		last_printed_guid = guid;
+			//	}
+			//}
+		} else {
+			//name.assign(cached_name);
+			return cached_T;
+		}
+			
+		}
+};
+
+#endif // RULE_LOOKUP_CACHE_H_

--- a/README.md
+++ b/README.md
@@ -600,6 +600,6 @@ Which renders as:
 
 # Building
 
-To build with CMake, first install "Visual Studio Build Tools 2017" and a version of CMake>=3.7. Visual Studio Build Tools comes with a "Developer Command Prompt" that sets up the path with the right compilers and build tools. Next, create a build directory within the project root directory and make it the current working directory. Then, run the command `cmake -G"Visual Studio 15 2017" -DCMAKE_BUILD_SHARED_LIBS=TRUE -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE ..` (save this command as a bat script if you like). This will create all necessary build files. Next, run `cmake --build . --config Release` to build the project.
+To build with CMake, first install "Visual Studio Build Tools 2017" and a version of CMake>=3.7. Visual Studio Build Tools comes with a "Developer Command Prompt" that sets up the path with the right compilers and build tools. Next, create a build directory within the project root directory and make it the current working directory. Then, run the command `cmake -G"Visual Studio 15 2017" -DBUILD_SHARED_LIBS=TRUE -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE ..` (save this command as a bat script if you like). This will create all necessary build files. Next, run `cmake --build . --config Release` to build the project.
 
 To enable multi-processor support when buildling, set the CXXFLAGS environment variable with `set CXXFLAGS=/MP` prior to running the cmake command above.

--- a/ThirdParty/cpp-lru-cache/.gitignore
+++ b/ThirdParty/cpp-lru-cache/.gitignore
@@ -1,0 +1,11 @@
+CMakeCache.txt
+CMakeFiles
+Makefile
+install_manifest.txt
+cmake_install.cmake
+
+nbproject
+build
+
+cpp-lru-cache-test
+obj-x86_64-linux-gnu/

--- a/ThirdParty/cpp-lru-cache/.travis.yml
+++ b/ThirdParty/cpp-lru-cache/.travis.yml
@@ -1,0 +1,13 @@
+language: cpp
+
+compiler:
+    - gcc
+  
+script: 
+    - mkdir build
+    - cd build
+    - cmake ..
+    - make check
+
+notifications:
+    email: false

--- a/ThirdParty/cpp-lru-cache/CMakeLists.txt
+++ b/ThirdParty/cpp-lru-cache/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(CPP-LRU_CACHE)
+
+find_package(Threads REQUIRED)
+
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+set(EXT_PROJECTS_DIR ${PROJECT_SOURCE_DIR}/ext)
+add_subdirectory(${EXT_PROJECTS_DIR}/gtest)
+
+enable_testing()
+
+include_directories(
+    ${GTEST_INCLUDE_DIRS}
+    ${PROJECT_SOURCE_DIR}/include)
+
+add_executable(
+    cpp-lru-cache-test
+    src/test)
+
+add_dependencies(cpp-lru-cache-test googletest)
+
+target_link_libraries(
+    cpp-lru-cache-test
+    ${GTEST_LIBS_DIR}/libgtest.a
+    ${GTEST_LIBS_DIR}/libgtest_main.a
+    ${CMAKE_THREAD_LIBS_INIT})
+
+set_target_properties(cpp-lru-cache-test PROPERTIES
+    PREFIX ""
+    SUFFIX ""
+    COMPILE_FLAGS "-std=c++0x -W -Wall -pedantic")
+
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g3")
+set(CMAKE_CSS_FLAGS_RELEASE "-03 -g")
+
+add_test(
+    NAME cpp-lru-cache-test
+    COMMAND cpp-lru-cache-test
+)
+
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --verbose
+    DEPENDS cpp-lru-cache-test)

--- a/ThirdParty/cpp-lru-cache/LICENSE
+++ b/ThirdParty/cpp-lru-cache/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2014, lamerman
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of lamerman nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ThirdParty/cpp-lru-cache/README.md
+++ b/ThirdParty/cpp-lru-cache/README.md
@@ -1,0 +1,29 @@
+cpp-lru-cache
+=============
+
+Simple and reliable LRU (Least Recently Used) cache for c++ based on hashmap and linkedlist. The library is header only, simple test and example are included.
+It includes standard components and very little own logics that guarantees reliability.
+
+Example:
+
+```
+/**Creates cache with maximum size of three. When the 
+   size in achieved every next element will replace the 
+   least recently used one */
+cache::lru_cache<std::string, std::string> cache(3);
+
+cache.put("one", "one");
+cache.put("two", "two");
+
+const std::string& from_cache = cache.get("two")
+
+```
+
+How to run tests:
+
+```
+mkdir build
+cd build
+cmake ..
+make check
+```

--- a/ThirdParty/cpp-lru-cache/ext/gtest/CMakeLists.txt
+++ b/ThirdParty/cpp-lru-cache/ext/gtest/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 2.8)
+project(gtest_builder C CXX)
+include(ExternalProject)
+
+ExternalProject_Add(googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG release-1.7.0
+    CMAKE_ARGS -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG:PATH=DebugLibs
+               -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE:PATH=ReleaseLibs
+               -DCMAKE_CXX_FLAGS=${MSVC_COMPILER_DEFS}
+               -Dgtest_force_shared_crt=ON
+     PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
+    INSTALL_COMMAND ""
+    UPDATE_COMMAND ""
+)
+
+ExternalProject_Get_Property(googletest source_dir)
+set(GTEST_INCLUDE_DIRS ${source_dir}/include PARENT_SCOPE)
+
+ExternalProject_Get_Property(googletest binary_dir)
+set(GTEST_LIBS_DIR ${binary_dir} PARENT_SCOPE)

--- a/ThirdParty/cpp-lru-cache/include/lrucache.hpp
+++ b/ThirdParty/cpp-lru-cache/include/lrucache.hpp
@@ -1,0 +1,72 @@
+/* 
+ * File:   lrucache.hpp
+ * Author: Alexander Ponomarev
+ *
+ * Created on June 20, 2013, 5:09 PM
+ */
+
+#ifndef _LRUCACHE_HPP_INCLUDED_
+#define	_LRUCACHE_HPP_INCLUDED_
+
+#include <unordered_map>
+#include <list>
+#include <cstddef>
+#include <stdexcept>
+
+namespace cache {
+
+template<typename key_t, typename value_t>
+class lru_cache {
+public:
+	typedef typename std::pair<key_t, value_t> key_value_pair_t;
+	typedef typename std::list<key_value_pair_t>::iterator list_iterator_t;
+
+	lru_cache(size_t max_size) :
+		_max_size(max_size) {
+	}
+	
+	void put(const key_t& key, const value_t& value) {
+		auto it = _cache_items_map.find(key);
+		_cache_items_list.push_front(key_value_pair_t(key, value));
+		if (it != _cache_items_map.end()) {
+			_cache_items_list.erase(it->second);
+			_cache_items_map.erase(it);
+		}
+		_cache_items_map[key] = _cache_items_list.begin();
+		
+		if (_cache_items_map.size() > _max_size) {
+			auto last = _cache_items_list.end();
+			last--;
+			_cache_items_map.erase(last->first);
+			_cache_items_list.pop_back();
+		}
+	}
+	
+	const value_t& get(const key_t& key) {
+		auto it = _cache_items_map.find(key);
+		if (it == _cache_items_map.end()) {
+			throw std::range_error("There is no such key in cache");
+		} else {
+			_cache_items_list.splice(_cache_items_list.begin(), _cache_items_list, it->second);
+			return it->second->second;
+		}
+	}
+	
+	bool exists(const key_t& key) const {
+		return _cache_items_map.find(key) != _cache_items_map.end();
+	}
+	
+	size_t size() const {
+		return _cache_items_map.size();
+	}
+	
+private:
+	std::list<key_value_pair_t> _cache_items_list;
+	std::unordered_map<key_t, list_iterator_t> _cache_items_map;
+	size_t _max_size;
+};
+
+} // namespace cache
+
+#endif	/* _LRUCACHE_HPP_INCLUDED_ */
+

--- a/ThirdParty/cpp-lru-cache/src/test.cpp
+++ b/ThirdParty/cpp-lru-cache/src/test.cpp
@@ -1,0 +1,45 @@
+#include "lrucache.hpp"
+#include "gtest/gtest.h"
+
+const int NUM_OF_TEST1_RECORDS = 100;
+const int NUM_OF_TEST2_RECORDS = 100;
+const int TEST2_CACHE_CAPACITY = 50;
+
+TEST(CacheTest, SimplePut) {
+    cache::lru_cache<int, int> cache_lru(1);
+    cache_lru.put(7, 777);
+    EXPECT_TRUE(cache_lru.exists(7));
+    EXPECT_EQ(777, cache_lru.get(7));
+    EXPECT_EQ(1, cache_lru.size());
+}
+
+TEST(CacheTest, MissingValue) {
+    cache::lru_cache<int, int> cache_lru(1);
+    EXPECT_THROW(cache_lru.get(7), std::range_error);
+}
+
+TEST(CacheTest1, KeepsAllValuesWithinCapacity) {
+    cache::lru_cache<int, int> cache_lru(TEST2_CACHE_CAPACITY);
+
+    for (int i = 0; i < NUM_OF_TEST2_RECORDS; ++i) {
+        cache_lru.put(i, i);
+    }
+
+    for (int i = 0; i < NUM_OF_TEST2_RECORDS - TEST2_CACHE_CAPACITY; ++i) {
+        EXPECT_FALSE(cache_lru.exists(i));
+    }
+
+    for (int i = NUM_OF_TEST2_RECORDS - TEST2_CACHE_CAPACITY; i < NUM_OF_TEST2_RECORDS; ++i) {
+        EXPECT_TRUE(cache_lru.exists(i));
+        EXPECT_EQ(i, cache_lru.get(i));
+    }
+
+    size_t size = cache_lru.size();
+    EXPECT_EQ(TEST2_CACHE_CAPACITY, size);
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    int ret = RUN_ALL_TESTS();
+    return ret;
+}


### PR DESCRIPTION
When joining a game, players try to form parties as before. That is they freely send invites and accept them. After all players are in a party, we then check that all players are in the same party. If they aren't, the players with the higher wPartyId will leave and then join the party with the lowest wPartyId. Thus, the earliest party formed has priority.

This PR includes #40. I chose to do it this way since this version has already been released as 1.9.8alpha3.

Edit:
Now updated to 1.9.8alpha5. Includes bug fixes to my autoparty changes. Also includes a memory leak fix (item rules and conditions not deleted when uninitialized).