### PR TITLE
Added four new colors

### DIFF
--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -27,7 +27,11 @@
 	{"ORANGE", "ÿc8"},		\
 	{"YELLOW", "ÿc9"},		\
 	{"PURPLE", "ÿc;"},		\
-	{"DARK_GREEN", "ÿc:"}
+	{"DARK_GREEN", "ÿc:"},	\
+	{"CORAL", "\xFF" "c\x06"},		\
+	{"SAGE", "\xFF" "c\x07"},		\
+	{"TEAL", "\xFF" "c\x09"},		\
+	{"LIGHT_GRAY", "\xFF" "c\x0C"}
 
 #define MAP_COLOR_WHITE     0x20
 
@@ -43,7 +47,11 @@
 	{"ORANGE", 0x60},		\
 	{"YELLOW", 0x0C},		\
 	{"PURPLE", 0x9B},		\
-	{"DARK_GREEN", 0x76}
+	{"DARK_GREEN", 0x76},	\
+	{"CORAL", 0x66},		\
+	{"SAGE", 0x82},			\
+	{"TEAL", 0xCB},			\
+	{"LIGHT_GRAY", 0xD6}
 
 enum Operation {
 	EQUAL,

--- a/BH/Modules/Maphack/Maphack.cpp
+++ b/BH/Modules/Maphack/Maphack.cpp
@@ -74,6 +74,10 @@ void Maphack::ReadConfig() {
 	TextColorMap["\377c9"] = 0x0C;  // yellow
 	TextColorMap["\377c;"] = 0x9B;  // purple
 	TextColorMap["\377c:"] = 0x76;  // dark green
+	TextColorMap["\377c\x06"] = 0x66; // coral
+	TextColorMap["\377c\x07"] = 0x82; // sage
+	TextColorMap["\377c\x09"] = 0xCB; // teal
+	TextColorMap["\377c\x0C"] = 0xD6; // light gray
 
 	BH::config->ReadAssoc("Monster Color", MonsterColors);
 	for (auto it = MonsterColors.cbegin(); it != MonsterColors.cend(); it++) {


### PR DESCRIPTION
Added four new colors: `CORAL`, `SAGE`, `TEAL`, and `LIGHT_GRAY`. These work the same as existing colors (that is, text and map color is supported).

Here is what the text looks like in game:
![image](https://user-images.githubusercontent.com/39288882/77086536-23e37280-69bf-11ea-93f0-776ad768f314.png)

Here is a full map of the available text colors:
![image](https://user-images.githubusercontent.com/39288882/77086709-5c834c00-69bf-11ea-81eb-b93190ef5a7c.png)

The row and column numbers are the first and second hex digit of the color code, respectively. Color codes for text use the format `\377c<code>`. So `\377c0=\377c\x30` maps to row 3, column 0. Likewise, `SAGE` is `\377c\x07`.

Edit: This only works in -3dfx mode :(