### PR TITLE
Configurable item description, native-looking ilvl/alvl display

### DIFF
--- a/BH/Constants.h
+++ b/BH/Constants.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define BH_VERSION "BH 1.9.9-b2"
+#define BH_VERSION "BH 1.9.9-b3"
 
 #define CODE_PAGE 1252 // windows-1252	ANSI Latin 1; Western European (Windows)
 

--- a/BH/Constants.h
+++ b/BH/Constants.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define BH_VERSION "BH 1.9.9-b1"
+#define BH_VERSION "BH 1.9.9-b2"
 
 #define CODE_PAGE 1252 // windows-1252	ANSI Latin 1; Western European (Windows)
 

--- a/BH/Constants.h
+++ b/BH/Constants.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define BH_VERSION "BH 1.9.8"
+#define BH_VERSION "BH 1.9.9-b1"
 
 #define CODE_PAGE 1252 // windows-1252	ANSI Latin 1; Western European (Windows)
 

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -90,6 +90,7 @@ void Item::OnLoad() {
 void Item::OnGameJoin() {
 	// reset the item name cache upon joining games
 	// (GUIDs not unique across games)
+	item_desc_cache.ResetCache();
 	item_name_cache.ResetCache();
 	map_action_cache.ResetCache();
 }

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -591,8 +591,7 @@ static ItemsTxt* GetArmorText(UnitAny* pItem) {
 void __stdcall Item::OnProperties(wchar_t * wTxt)
 {
 	const int MAXLEN = 1024;
-	const int DESCLEN = 128;
-	static wchar_t wDesc[DESCLEN];// a buffer for converting the description
+	static wchar_t wDesc[128];// a buffer for converting the description
 	UnitAny* pItem = *p_D2CLIENT_SelectedInvItem;
 	UnitItemInfo uInfo;
 	if (!pItem || pItem->dwType != UNIT_ITEM || CreateUnitItemInfo(&uInfo, pItem)) {
@@ -604,7 +603,7 @@ void __stdcall Item::OnProperties(wchar_t * wTxt)
 		int aLen = wcslen(wTxt);
 		string desc = item_desc_cache.Get(&uInfo);
 		if (desc != "") {
-			auto chars_written = MultiByteToWideChar(CODE_PAGE, MB_PRECOMPOSED, desc.c_str(), -1, wDesc, DESCLEN);
+			auto chars_written = MultiByteToWideChar(CODE_PAGE, MB_PRECOMPOSED, desc.c_str(), -1, wDesc, 128);
 			swprintf_s(wTxt + aLen, MAXLEN - aLen,
 				L"%s%s\n",
 				(chars_written > 0) ? wDesc : L"\377c1 Descirption string too long!",

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -590,7 +590,8 @@ static ItemsTxt* GetArmorText(UnitAny* pItem) {
 void __stdcall Item::OnProperties(wchar_t * wTxt)
 {
 	const int MAXLEN = 1024;
-	static wchar_t wDesc[MAXLEN];// a buffer for converting the description
+	const int DESCLEN = 128;
+	static wchar_t wDesc[DESCLEN];// a buffer for converting the description
 	UnitAny* pItem = *p_D2CLIENT_SelectedInvItem;
 	UnitItemInfo uInfo;
 	if (CreateUnitItemInfo(&uInfo, pItem)) {
@@ -609,11 +610,10 @@ void __stdcall Item::OnProperties(wchar_t * wTxt)
 		int aLen = wcslen(wTxt);
 		string desc = item_desc_cache.Get(&uInfo);
 		if (desc != "") {
-			MultiByteToWideChar(CODE_PAGE, MB_PRECOMPOSED, desc.c_str(), desc.length(), wDesc, desc.length());
-			wDesc[desc.length()] = 0;  // null-terminate the string since MultiByteToWideChar doesn't
+			auto chars_written = MultiByteToWideChar(CODE_PAGE, MB_PRECOMPOSED, desc.c_str(), -1, wDesc, DESCLEN);
 			swprintf_s(wTxt + aLen, MAXLEN - aLen,
 				L"%s%s\n",
-				wDesc,
+				(chars_written > 0) ? wDesc : L"\377c1 Descirption string too long!",
 				GetColorCode(TextColor::White).c_str());
 		}
 	}

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -604,15 +604,15 @@ void __stdcall Item::OnProperties(wchar_t * wTxt)
 	}
 
 	// Add description
-	//{
-	//	int aLen = wcslen(wTxt);
-	//	swprintf_s(wTxt + aLen, MAXLEN - aLen,
-	//			L"%sLen: %d The %squick %sbrown fox jumps over the lazy dog.\n",
-	//			GetColorCode(TextColor::White).c_str(),
-	//			aLen,
-	//			GetColorCode(TextColor::Orange).c_str(),
-	//			GetColorCode(TextColor::White).c_str());
-	//}
+	{
+		int aLen = wcslen(wTxt);
+		string desc = item_desc_cache.Get(&uInfo);
+		std::wstring wDesc = std::wstring(desc.begin(), desc.end());
+		swprintf_s(wTxt + aLen, MAXLEN - aLen,
+				L"%s%s\n",
+				wDesc.c_str(),
+				GetColorCode(TextColor::White).c_str());
+	}
 
 	//Any Armor ItemTypes.txt
 	if (D2COMMON_IsMatchingType(pItem, ITEM_TYPE_ALLARMOR)) {

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -590,6 +590,7 @@ static ItemsTxt* GetArmorText(UnitAny* pItem) {
 void __stdcall Item::OnProperties(wchar_t * wTxt)
 {
 	const int MAXLEN = 1024;
+	static wchar_t wDesc[MAXLEN];// a buffer for converting the description
 	UnitAny* pItem = *p_D2CLIENT_SelectedInvItem;
 	UnitItemInfo uInfo;
 	if (CreateUnitItemInfo(&uInfo, pItem)) {
@@ -607,11 +608,14 @@ void __stdcall Item::OnProperties(wchar_t * wTxt)
 	{
 		int aLen = wcslen(wTxt);
 		string desc = item_desc_cache.Get(&uInfo);
-		std::wstring wDesc = std::wstring(desc.begin(), desc.end());
-		swprintf_s(wTxt + aLen, MAXLEN - aLen,
+		if (desc != "") {
+			MultiByteToWideChar(CODE_PAGE, MB_PRECOMPOSED, desc.c_str(), desc.length(), wDesc, desc.length());
+			wDesc[desc.length()] = 0;  // null-terminate the string since MultiByteToWideChar doesn't
+			swprintf_s(wTxt + aLen, MAXLEN - aLen,
 				L"%s%s\n",
-				wDesc.c_str(),
+				wDesc,
 				GetColorCode(TextColor::White).c_str());
+		}
 	}
 
 	//Any Armor ItemTypes.txt

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -93,6 +93,7 @@ void Item::OnGameJoin() {
 	item_desc_cache.ResetCache();
 	item_name_cache.ResetCache();
 	map_action_cache.ResetCache();
+	ignore_cache.ResetCache();
 }
 
 void Item::LoadConfig() {

--- a/BH/Modules/Item/Item.h
+++ b/BH/Modules/Item/Item.h
@@ -90,3 +90,5 @@ void GetItemPropertyString_Interception();
 void ViewInventoryPatch1_ASM();
 void ViewInventoryPatch2_ASM();
 void ViewInventoryPatch3_ASM();
+struct UnitItemInfo;
+int CreateUnitItemInfo(UnitItemInfo *uInfo, UnitAny *item);

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -522,7 +522,7 @@ string ParseDescription(Action *act) {
 	size_t start_idx = l_idx + 1;
 	size_t len = r_idx - start_idx;
 	string desc_string = act->name.substr(start_idx, len);
-	act->name.replace(start_idx, len, "");
+	act->name.replace(l_idx, len+2, "");
 	return desc_string;
 }
 

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -457,6 +457,7 @@ void BuildAction(string *str, Action *act) {
 	act->pxColor = ParseMapColor(act, "PX");
 	act->lineColor = ParseMapColor(act, "LINE");
 	act->notifyColor = ParseMapColor(act, "NOTIFY");
+	act->description = ParseDescription(act);
 
 	// legacy support:
 	size_t map = act->name.find("%MAP%");
@@ -485,6 +486,17 @@ void BuildAction(string *str, Action *act) {
 		act->name.replace(done, 10, "");
 		act->stopProcessing = false;
 	}
+}
+
+string ParseDescription(Action *act) {
+	size_t l_idx = act->name.find("{");
+	size_t r_idx = act->name.find("}");
+	if (l_idx == string::npos || r_idx == string::npos || l_idx > r_idx) return "";
+	size_t start_idx = l_idx + 1;
+	size_t len = r_idx - start_idx;
+	string desc_string = act->name.substr(start_idx, len);
+	act->name.replace(start_idx, len, "");
+	return desc_string;
 }
 
 int ParseMapColor(Action *act, const string& key_string) {

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -524,6 +524,7 @@ struct SkillReplace {
 struct Action {
 	bool stopProcessing;
 	string name;
+	string description;
 	int colorOnMap;
 	int borderColor;
 	int dotColor;
@@ -538,7 +539,8 @@ struct Action {
 		lineColor(UNDEFINED_COLOR),
 		notifyColor(UNDEFINED_COLOR),
 		stopProcessing(true),
-		name("") {}
+		name(""),
+		description("") {}
 };
 
 struct Rule {
@@ -631,6 +633,7 @@ namespace ItemDisplay {
 }
 StatProperties *GetStatProperties(unsigned int stat);
 void BuildAction(string *str, Action *act);
+string ParseDescription(Action *act);
 int ParseMapColor(Action *act, const string& reg_string);
 void HandleUnknownItemCode(char *code, char *tag);
 BYTE GetOperation(string *op);

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -629,13 +629,25 @@ class MapActionLookupCache : public RuleLookupCache<vector<Action>> {
 			RuleLookupCache<vector<Action>>(RuleList) {}
 };
 
+class IgnoreLookupCache : public RuleLookupCache<bool> {
+	bool make_cached_T(UnitItemInfo *uInfo) override;
+	string to_str(const bool &ignore);
+
+		public:
+		IgnoreLookupCache(const std::vector<Rule*> &RuleList) :
+			RuleLookupCache<bool>(RuleList) {}
+};
+
 extern vector<Rule*> RuleList;
+extern vector<Rule*> NameRuleList;
+extern vector<Rule*> DescRuleList;
 extern vector<Rule*> MapRuleList;
 extern vector<Rule*> IgnoreRuleList;
 extern vector<pair<string, string>> rules;
 extern ItemDescLookupCache item_desc_cache;
 extern ItemNameLookupCache item_name_cache;
 extern MapActionLookupCache map_action_cache;
+extern IgnoreLookupCache ignore_cache;
 
 namespace ItemDisplay {
 	void InitializeItemRules();

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -602,6 +602,15 @@ struct Rule {
 	}
 };
 
+class ItemDescLookupCache : public RuleLookupCache<string> {
+	string make_cached_T(UnitItemInfo *uInfo) override;
+	string to_str(const string &name) override;
+
+		public:
+		ItemDescLookupCache(const std::vector<Rule*> &RuleList) :
+			RuleLookupCache<string>(RuleList) {}
+};
+
 class ItemNameLookupCache : public RuleLookupCache<string, const string &> {
 	string make_cached_T(UnitItemInfo *uInfo, const string &name) override;
 	string to_str(const string &name) override;
@@ -624,6 +633,7 @@ extern vector<Rule*> RuleList;
 extern vector<Rule*> MapRuleList;
 extern vector<Rule*> IgnoreRuleList;
 extern vector<pair<string, string>> rules;
+extern ItemDescLookupCache item_desc_cache;
 extern ItemNameLookupCache item_name_cache;
 extern MapActionLookupCache map_action_cache;
 
@@ -639,7 +649,7 @@ void HandleUnknownItemCode(char *code, char *tag);
 BYTE GetOperation(string *op);
 inline bool IntegerCompare(unsigned int Lvalue, int operation, unsigned int Rvalue);
 void GetItemName(UnitItemInfo *uInfo, string &name);
-void SubstituteNameVariables(UnitItemInfo *uInfo, string &name, Action *action);
+void SubstituteNameVariables(UnitItemInfo *uInfo, string &name, const string &action_name);
 int GetDefense(ItemInfo *item);
 BYTE GetAffixLevel(BYTE ilvl, BYTE qlvl, BYTE mlvl);
 BYTE GetRequiredLevel(UnitAny* item);

--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ Mustache[header]: {{>header-unique}}{{>header-magic}}{{>header-else}}{{#count}} 
 Mustache[item]: {{>header}}{{>stats}}{{^isRuneword}}{{#socketed}}\n\n  * {{>>item}}{{/socketed}}{{/isRuneword}}\n
 Mustache[stash]: {{#this}}* {{>item}}\n\n{{/this}}
 ```
+
+# Release Notes for 1.9.9-b1
+* Adds support for a configurable item description field. The description goes in curly braces `{}`. "Advanced Item Display" must be on for the description to show. For example, you can add a hint to ebug armors with the following.
+```ItemDisplay[!RW ETH !SUP CHEST NMAG SOCK=0]: %NAME%{%WHITE%Add sockets in cube with Tal+Thul+%YELLOW%o%WHITE%Perfect}
+```
+* The item description field supports the same keywords as the normal item name, so `%ILVL%` will work as expected, for example. 
+* The `%NAME%` keyword behaves much the same way as well, except that it will insert the previous *description*, not the item's name. This only make sense when `%CONTINUE%` is used. The result of the following is that an ebug-eligible armor with 667+ defense will display "A good EBUG base. Add sockets...". If `%NAME%` is used without a description being set on another matching `ItemDisplay` line first, it will resolve to a blank string.
+```ItemDisplay[!RW ETH !SUP CHEST NMAG SOCK=0 DEF>666]: %NAME%{%WHITE% A good EBUG base.}%CONTINUE%
+ItemDisplay[!RW ETH !SUP CHEST NMAG SOCK=0]: %NAME%{%NAME% %WHITE%Add sockets in cube with Tal+Thul+%YELLOW%O%WHITE%Perfect}```
+* The item level and affix level can now be displayed as part of the item's properties (like required level, durability, etc.). To enable this, "Advanced Item Display" and "Show iLvl" must be on.
+
 # Release Notes for 1.9.8
 ## Bug fixes
 * `BOW` and `SCEPTER` item groups now work correctly

--- a/README.md
+++ b/README.md
@@ -65,13 +65,16 @@ Mustache[stash]: {{#this}}* {{>item}}\n\n{{/this}}
 ```
 
 # Release Notes for 1.9.9-b1
-* Adds support for a configurable item description field. The description goes in curly braces `{}`. "Advanced Item Display" must be on for the description to show. For example, you can add a hint to ebug armors with the following.
-```ItemDisplay[!RW ETH !SUP CHEST NMAG SOCK=0]: %NAME%{%WHITE%Add sockets in cube with Tal+Thul+%YELLOW%o%WHITE%Perfect}
+* Adds support for a configurable item description field. This field is shown in game along with the item properties (like required level, durability, etc.). It's useful for information you want to display with the item that doesn't need to be part of the item's name. The description goes in curly braces `{}`. "Advanced Item Display" must be on for the description to show. For example, you can add a hint to ebug armors with the following. [more info](https://github.com/planqi/slashdiablo-maphack/pull/46)
+```
+ItemDisplay[!RW ETH !SUP CHEST NMAG SOCK=0]: %NAME%{%WHITE%Add sockets in cube with Tal+Thul+%YELLOW%o%WHITE%Perfect}
 ```
 * The item description field supports the same keywords as the normal item name, so `%ILVL%` will work as expected, for example. 
-* The `%NAME%` keyword behaves much the same way as well, except that it will insert the previous *description*, not the item's name. This only make sense when `%CONTINUE%` is used. The result of the following is that an ebug-eligible armor with 667+ defense will display "A good EBUG base. Add sockets...". If `%NAME%` is used without a description being set on another matching `ItemDisplay` line first, it will resolve to a blank string.
-```ItemDisplay[!RW ETH !SUP CHEST NMAG SOCK=0 DEF>666]: %NAME%{%WHITE% A good EBUG base.}%CONTINUE%
-ItemDisplay[!RW ETH !SUP CHEST NMAG SOCK=0]: %NAME%{%NAME% %WHITE%Add sockets in cube with Tal+Thul+%YELLOW%O%WHITE%Perfect}```
+* The `%NAME%` keyword behaves much the same way as well, except that when in curly braces `{}`, it will insert the previous *description*, not the item's name. This only make sense when `%CONTINUE%` is used. The result of the following is that an ebug-eligible armor with 667+ defense will display "A good EBUG base. Add sockets...". If `%NAME%` is used without a description being set on another matching `ItemDisplay` line first, it will resolve to a blank string. There are no changes to how `%NAME%` works outside curly braces `{}`.
+```
+ItemDisplay[!RW ETH !SUP CHEST NMAG SOCK=0 DEF>666]: %NAME%{%WHITE% A good EBUG base.}%CONTINUE%
+ItemDisplay[!RW ETH !SUP CHEST NMAG SOCK=0]: %NAME%{%NAME% %WHITE%Add sockets in cube with Tal+Thul+%YELLOW%O%WHITE%Perfect}
+```
 * The item level and affix level can now be displayed as part of the item's properties (like required level, durability, etc.). To enable this, "Advanced Item Display" and "Show iLvl" must be on.
 
 # Release Notes for 1.9.8


### PR DESCRIPTION
Original
---------
This feature adds a configurable item description that the user can set through `BH.cfg`. The syntax is as follows:

```ItemDisplay[blah]: %NAME%{my description}```

The description field can tell players more about items they pick up due to a notification (e.g., in a default config). It can also give relevant cube recipes, possible runewords, etc. The description is only displayed on the item if "Advanced Item Display" is active.

Here's an example that adds description text to a Titan's Revenge.
![image](https://user-images.githubusercontent.com/39288882/77382587-fdfefa80-6d3d-11ea-8f1d-2525e782c222.png)

Because much of the code that controls item name display was reused, many of the same features still work. That is, all keywords like colors, etc. are supported. Even the `%NAME%` directive still has meaning. For example:
![image](https://user-images.githubusercontent.com/39288882/77383369-f93b4600-6d3f-11ea-9d41-9994088310d6.png)

The above example shows that `%CONTINUE%` still applies as before. However, when `%NAME%` is used in the description field, it uses the last set description, not the item name.

If no `%CONTINUE%` is used, the behavior is as expected:
![image](https://user-images.githubusercontent.com/39288882/77383269-b5484100-6d3f-11ea-81b9-6895ea3ba0f0.png)


Here's an example showing that the `%ILVL%` keyword still works in the description field:
![image](https://user-images.githubusercontent.com/39288882/77382927-e07e6080-6d3e-11ea-8429-4edca77da42b.png)

This PR also adds support for more native looking item level and affix level display. You can see the item level display above. Similarly, affix level is shown for magic, rare, and crafted quality items. Affix level is only shown if it is different than item level. Additionally, the user must set "Advanced Item Display" and "Show iLvl" for these features to be active. Here is the affix level display on some rare gloves:
![image](https://user-images.githubusercontent.com/39288882/77383136-54b90400-6d3f-11ea-91d8-554a44c610a3.png)

Update 3/25
--------------
* Description rule list is now separate from the main one. This allows for setting descriptions separate from item names, e.g.
```
ItemDisplay[blah]: %NAME%
ItemDisplay[blah]: {description}
```
* Tweak item rules slightly so that more conditions are required to create an ignore rule. Before, an ignore rule would be created in the following situations.
```
ItemDisplay[blah]: %MAP%
ItemDisplay[blah]: %NAME%
```
The above previously resulted in a blank item name. The item was not blocked because of the `%MAP% command, but still this is probably not desirable behavior. After this fix, the item name will no longer be blank.
```
ItemDisplay[blah]: %CONTINUE%
ItemDisplay[blah]: %NAME%
```
The above would also result in a blank item name. Additionally, the item will be blocked in this case. After the fix, the item name is preserved, and no ignore rule is created. This is kind of a corner case, but I think this is the more desirable behavior.
* After this fix, an ignore rule is only created when the item name and description are not blank, there is no map action, **and** there is no `%CONTINUE%` statement. Essentially only blank lines can create ignore rules now.
* Blank item names should no longer be generated as a result of the above changes. To warn users that an item they see in game will be blocked by the packet filter, a `[blocked]` tag is added to the item. For example:
![image](https://user-images.githubusercontent.com/39288882/77542745-e28e0f80-6e63-11ea-90c1-770a0a4f8871.png)
The blocked tag is only generated when the item has an ignore rule and not a map rule. This change also fixes some other undesirable behavior.
```
ItemDisplay[blah]: %NAME%%MAP%%CONTINUE%
ItemDisplay[blah]: 
```
Previously, the above would result in a blank item name, but the item would still spawn in game and ping. After the fix, the item name will no longer be blank. The item will ping as before.
