### PR TITLE
Item Detailed Notifications Improvements

### DIFF
--- a/BH/Constants.h
+++ b/BH/Constants.h
@@ -1020,7 +1020,8 @@ enum QuestFlags {
 #define ITEM_SWITCHOUT			0x00000080 // Switched out(deactivated)
 #define ITEM_BROKEN				0x00000100 // Broken(0 durability)
 #define ITEM_HASSOCKETS			0x00000800 // Has sockets
-#define ITEM_INSTORE			0x00002000 // In npc store or gamble screen
+#define ITEM_INSTORE			0x00002000 // In npc store or gamble screen TODO: remove this?
+#define ITEMFLAG_NEW			0x00002000 // This flag is called 'new' by Nefarius
 #define ITEM_ISEAR				0x00010000 // Player's ear
 #define ITEM_STARTITEM			0x00020000 // Start item(1 selling/repair value)
 #define ITEM_COMPACTSAVE		0x00200000 

--- a/BH/Modules/Maphack/Maphack.cpp
+++ b/BH/Modules/Maphack/Maphack.cpp
@@ -341,6 +341,7 @@ void Maphack::OnDraw() {
 	for (Room1* room1 = player->pAct->pRoom1; room1; room1 = room1->pRoomNext) {
 		for (UnitAny* unit = room1->pUnitFirst; unit; unit = unit->pListNext) {
 			if (unit->dwType == UNIT_ITEM && (unit->dwFlags & UNITFLAG_NO_EXPERIENCE) == 0x0) {
+				DWORD dwFlags = unit->pItemData->dwFlags;
 				UnitItemInfo uInfo;
 				uInfo.item = unit;
 				uInfo.itemCode[0] = D2COMMON_GetItemText(unit->dwTxtFileNo)->szCode[0];
@@ -353,6 +354,7 @@ void Maphack::OnDraw() {
 						if ((*it)->Evaluate(&uInfo, NULL)) {
 							if ((unit->dwFlags & UNITFLAG_REVEALED) == 0x0
 								 && (*BH::MiscToggles2)["Item Detailed Notifications"].state) {
+								if ((*BH::MiscToggles2)["Item Close Notifications"].state || (dwFlags & ITEMFLAG_NEW)) {
 									std::string itemName = GetItemName(unit);
 									size_t start_pos = 0;
 									while ((start_pos = itemName.find('\n', start_pos)) != std::string::npos) {
@@ -360,6 +362,8 @@ void Maphack::OnDraw() {
 										start_pos += 3;
 									}
 									PrintText(ItemColorFromQuality(unit->pItemData->dwQuality), "%s", itemName.c_str());
+									//PrintText(ItemColorFromQuality(unit->pItemData->dwQuality), "%s %x", itemName.c_str(), dwFlags);
+								}
 							}
 							unit->dwFlags |= UNITFLAG_REVEALED;
 							break;

--- a/BH/Modules/Maphack/Maphack.cpp
+++ b/BH/Modules/Maphack/Maphack.cpp
@@ -350,12 +350,17 @@ void Maphack::OnDraw() {
 				uInfo.itemCode[3] = 0;
 				if (ItemAttributeMap.find(uInfo.itemCode) != ItemAttributeMap.end()) {
 					uInfo.attrs = ItemAttributeMap[uInfo.itemCode];
-					for (vector<Rule*>::iterator it = MapRuleList.begin(); it != MapRuleList.end(); it++) {
-						if ((*it)->Evaluate(&uInfo, NULL)) {
+					vector<Action> actions = map_action_cache.Get(&uInfo);
+					for (auto &action : actions) {
+						if (action.colorOnMap != UNDEFINED_COLOR ||
+								action.borderColor != UNDEFINED_COLOR ||
+								action.dotColor != UNDEFINED_COLOR ||
+								action.pxColor != UNDEFINED_COLOR ||
+								action.lineColor != UNDEFINED_COLOR) { // has map action
 							unit->dwFlags |= UNITFLAG_REVEALED;
 							if ((*BH::MiscToggles2)["Item Detailed Notifications"].state
 							  && ((*BH::MiscToggles2)["Item Close Notifications"].state || (dwFlags & ITEMFLAG_NEW))
-							  && (*it)->action.notifyColor != DEAD_COLOR) {
+							  && action.notifyColor != DEAD_COLOR) {
 								std::string itemName = GetItemName(unit);
 								size_t start_pos = 0;
 								while ((start_pos = itemName.find('\n', start_pos)) != std::string::npos) {
@@ -366,6 +371,7 @@ void Maphack::OnDraw() {
 								//PrintText(ItemColorFromQuality(unit->pItemData->dwQuality), "%s %x", itemName.c_str(), dwFlags);
 								break;
 							}
+
 						}
 					}
 				}

--- a/BH/Modules/Maphack/Maphack.cpp
+++ b/BH/Modules/Maphack/Maphack.cpp
@@ -352,21 +352,20 @@ void Maphack::OnDraw() {
 					uInfo.attrs = ItemAttributeMap[uInfo.itemCode];
 					for (vector<Rule*>::iterator it = MapRuleList.begin(); it != MapRuleList.end(); it++) {
 						if ((*it)->Evaluate(&uInfo, NULL)) {
-							if ((unit->dwFlags & UNITFLAG_REVEALED) == 0x0
-								 && (*BH::MiscToggles2)["Item Detailed Notifications"].state) {
-								if ((*BH::MiscToggles2)["Item Close Notifications"].state || (dwFlags & ITEMFLAG_NEW)) {
-									std::string itemName = GetItemName(unit);
-									size_t start_pos = 0;
-									while ((start_pos = itemName.find('\n', start_pos)) != std::string::npos) {
-										itemName.replace(start_pos, 1, " - ");
-										start_pos += 3;
-									}
-									PrintText(ItemColorFromQuality(unit->pItemData->dwQuality), "%s", itemName.c_str());
-									//PrintText(ItemColorFromQuality(unit->pItemData->dwQuality), "%s %x", itemName.c_str(), dwFlags);
-								}
-							}
 							unit->dwFlags |= UNITFLAG_REVEALED;
-							break;
+							if ((*BH::MiscToggles2)["Item Detailed Notifications"].state
+							  && ((*BH::MiscToggles2)["Item Close Notifications"].state || (dwFlags & ITEMFLAG_NEW))
+							  && (*it)->action.notifyColor != DEAD_COLOR) {
+								std::string itemName = GetItemName(unit);
+								size_t start_pos = 0;
+								while ((start_pos = itemName.find('\n', start_pos)) != std::string::npos) {
+									itemName.replace(start_pos, 1, " - ");
+									start_pos += 3;
+								}
+								PrintText(ItemColorFromQuality(unit->pItemData->dwQuality), "%s", itemName.c_str());
+								//PrintText(ItemColorFromQuality(unit->pItemData->dwQuality), "%s %x", itemName.c_str(), dwFlags);
+								break;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
* "Item detailed notifications" works as before when "Item Close Notifications" is enabled.
* When "Item Close Notifications" is disabled, the detailed notifications are no longer generated when you leave an area and return to the item or when you drop an item. This uses `ITEMFLAG_NEW` described [here](https://d2mods.info/forum/viewtopic.php?p=486829#p486829). Also see the 4th hex digit in the test below, i.e., a0**2**010.
![image](https://user-images.githubusercontent.com/39288882/78140735-52117b00-73df-11ea-8734-2663def2af8b.png)
* The loop that iterated each item in a room to check against each map rule has been replaced with a lookup from the map action cache.
* `%notify-dead%` is now supported with detailed notifications.