### PR TITLE
Item name whitelisting

### DIFF
--- a/BH/Constants.h
+++ b/BH/Constants.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define BH_VERSION "BH 1.9.9-b2"
+#define BH_VERSION "BH 1.9.9-b3"
 
 #define CODE_PAGE 1252 // windows-1252	ANSI Latin 1; Western European (Windows)
 

--- a/BH/Constants.h
+++ b/BH/Constants.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define BH_VERSION "BH 1.9.9-b1"
+#define BH_VERSION "BH 1.9.9-b2"
 
 #define CODE_PAGE 1252 // windows-1252	ANSI Latin 1; Western European (Windows)
 

--- a/BH/Constants.h
+++ b/BH/Constants.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define BH_VERSION "BH 1.9.8"
+#define BH_VERSION "BH 1.9.9-b1"
 
 #define CODE_PAGE 1252 // windows-1252	ANSI Latin 1; Western European (Windows)
 

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -90,6 +90,7 @@ void Item::OnLoad() {
 void Item::OnGameJoin() {
 	// reset the item name cache upon joining games
 	// (GUIDs not unique across games)
+	item_desc_cache.ResetCache();
 	item_name_cache.ResetCache();
 	map_action_cache.ResetCache();
 }

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -591,8 +591,7 @@ static ItemsTxt* GetArmorText(UnitAny* pItem) {
 void __stdcall Item::OnProperties(wchar_t * wTxt)
 {
 	const int MAXLEN = 1024;
-	const int DESCLEN = 128;
-	static wchar_t wDesc[DESCLEN];// a buffer for converting the description
+	static wchar_t wDesc[128];// a buffer for converting the description
 	UnitAny* pItem = *p_D2CLIENT_SelectedInvItem;
 	UnitItemInfo uInfo;
 	if (!pItem || pItem->dwType != UNIT_ITEM || CreateUnitItemInfo(&uInfo, pItem)) {
@@ -604,7 +603,7 @@ void __stdcall Item::OnProperties(wchar_t * wTxt)
 		int aLen = wcslen(wTxt);
 		string desc = item_desc_cache.Get(&uInfo);
 		if (desc != "") {
-			auto chars_written = MultiByteToWideChar(CODE_PAGE, MB_PRECOMPOSED, desc.c_str(), -1, wDesc, DESCLEN);
+			auto chars_written = MultiByteToWideChar(CODE_PAGE, MB_PRECOMPOSED, desc.c_str(), -1, wDesc, 128);
 			swprintf_s(wTxt + aLen, MAXLEN - aLen,
 				L"%s%s\n",
 				(chars_written > 0) ? wDesc : L"\377c1 Descirption string too long!",

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -590,7 +590,8 @@ static ItemsTxt* GetArmorText(UnitAny* pItem) {
 void __stdcall Item::OnProperties(wchar_t * wTxt)
 {
 	const int MAXLEN = 1024;
-	static wchar_t wDesc[MAXLEN];// a buffer for converting the description
+	const int DESCLEN = 128;
+	static wchar_t wDesc[DESCLEN];// a buffer for converting the description
 	UnitAny* pItem = *p_D2CLIENT_SelectedInvItem;
 	UnitItemInfo uInfo;
 	if (CreateUnitItemInfo(&uInfo, pItem)) {
@@ -609,11 +610,10 @@ void __stdcall Item::OnProperties(wchar_t * wTxt)
 		int aLen = wcslen(wTxt);
 		string desc = item_desc_cache.Get(&uInfo);
 		if (desc != "") {
-			MultiByteToWideChar(CODE_PAGE, MB_PRECOMPOSED, desc.c_str(), desc.length(), wDesc, desc.length());
-			wDesc[desc.length()] = 0;  // null-terminate the string since MultiByteToWideChar doesn't
+			auto chars_written = MultiByteToWideChar(CODE_PAGE, MB_PRECOMPOSED, desc.c_str(), -1, wDesc, DESCLEN);
 			swprintf_s(wTxt + aLen, MAXLEN - aLen,
 				L"%s%s\n",
-				wDesc,
+				(chars_written > 0) ? wDesc : L"\377c1 Descirption string too long!",
 				GetColorCode(TextColor::White).c_str());
 		}
 	}

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -604,15 +604,15 @@ void __stdcall Item::OnProperties(wchar_t * wTxt)
 	}
 
 	// Add description
-	//{
-	//	int aLen = wcslen(wTxt);
-	//	swprintf_s(wTxt + aLen, MAXLEN - aLen,
-	//			L"%sLen: %d The %squick %sbrown fox jumps over the lazy dog.\n",
-	//			GetColorCode(TextColor::White).c_str(),
-	//			aLen,
-	//			GetColorCode(TextColor::Orange).c_str(),
-	//			GetColorCode(TextColor::White).c_str());
-	//}
+	{
+		int aLen = wcslen(wTxt);
+		string desc = item_desc_cache.Get(&uInfo);
+		std::wstring wDesc = std::wstring(desc.begin(), desc.end());
+		swprintf_s(wTxt + aLen, MAXLEN - aLen,
+				L"%s%s\n",
+				wDesc.c_str(),
+				GetColorCode(TextColor::White).c_str());
+	}
 
 	//Any Armor ItemTypes.txt
 	if (D2COMMON_IsMatchingType(pItem, ITEM_TYPE_ALLARMOR)) {

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -590,6 +590,7 @@ static ItemsTxt* GetArmorText(UnitAny* pItem) {
 void __stdcall Item::OnProperties(wchar_t * wTxt)
 {
 	const int MAXLEN = 1024;
+	static wchar_t wDesc[MAXLEN];// a buffer for converting the description
 	UnitAny* pItem = *p_D2CLIENT_SelectedInvItem;
 	UnitItemInfo uInfo;
 	if (CreateUnitItemInfo(&uInfo, pItem)) {
@@ -607,11 +608,14 @@ void __stdcall Item::OnProperties(wchar_t * wTxt)
 	{
 		int aLen = wcslen(wTxt);
 		string desc = item_desc_cache.Get(&uInfo);
-		std::wstring wDesc = std::wstring(desc.begin(), desc.end());
-		swprintf_s(wTxt + aLen, MAXLEN - aLen,
+		if (desc != "") {
+			MultiByteToWideChar(CODE_PAGE, MB_PRECOMPOSED, desc.c_str(), desc.length(), wDesc, desc.length());
+			wDesc[desc.length()] = 0;  // null-terminate the string since MultiByteToWideChar doesn't
+			swprintf_s(wTxt + aLen, MAXLEN - aLen,
 				L"%s%s\n",
-				wDesc.c_str(),
+				wDesc,
 				GetColorCode(TextColor::White).c_str());
+		}
 	}
 
 	//Any Armor ItemTypes.txt

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -93,6 +93,7 @@ void Item::OnGameJoin() {
 	item_desc_cache.ResetCache();
 	item_name_cache.ResetCache();
 	map_action_cache.ResetCache();
+	do_not_block_cache.ResetCache();
 	ignore_cache.ResetCache();
 }
 

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -93,6 +93,7 @@ void Item::OnGameJoin() {
 	item_desc_cache.ResetCache();
 	item_name_cache.ResetCache();
 	map_action_cache.ResetCache();
+	ignore_cache.ResetCache();
 }
 
 void Item::LoadConfig() {

--- a/BH/Modules/Item/Item.h
+++ b/BH/Modules/Item/Item.h
@@ -90,3 +90,5 @@ void GetItemPropertyString_Interception();
 void ViewInventoryPatch1_ASM();
 void ViewInventoryPatch2_ASM();
 void ViewInventoryPatch3_ASM();
+struct UnitItemInfo;
+int CreateUnitItemInfo(UnitItemInfo *uInfo, UnitAny *item);

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -522,7 +522,7 @@ string ParseDescription(Action *act) {
 	size_t start_idx = l_idx + 1;
 	size_t len = r_idx - start_idx;
 	string desc_string = act->name.substr(start_idx, len);
-	act->name.replace(start_idx, len, "");
+	act->name.replace(l_idx, len+2, "");
 	return desc_string;
 }
 

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -457,6 +457,7 @@ void BuildAction(string *str, Action *act) {
 	act->pxColor = ParseMapColor(act, "PX");
 	act->lineColor = ParseMapColor(act, "LINE");
 	act->notifyColor = ParseMapColor(act, "NOTIFY");
+	act->description = ParseDescription(act);
 
 	// legacy support:
 	size_t map = act->name.find("%MAP%");
@@ -485,6 +486,17 @@ void BuildAction(string *str, Action *act) {
 		act->name.replace(done, 10, "");
 		act->stopProcessing = false;
 	}
+}
+
+string ParseDescription(Action *act) {
+	size_t l_idx = act->name.find("{");
+	size_t r_idx = act->name.find("}");
+	if (l_idx == string::npos || r_idx == string::npos || l_idx > r_idx) return "";
+	size_t start_idx = l_idx + 1;
+	size_t len = r_idx - start_idx;
+	string desc_string = act->name.substr(start_idx, len);
+	act->name.replace(start_idx, len, "");
+	return desc_string;
 }
 
 int ParseMapColor(Action *act, const string& key_string) {

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -62,6 +62,7 @@ vector<Rule*> RuleList;
 vector<Rule*> NameRuleList;
 vector<Rule*> DescRuleList;
 vector<Rule*> MapRuleList;
+vector<Rule*> DoNotBlockRuleList;
 vector<Rule*> IgnoreRuleList;
 BYTE LastConditionType;
 
@@ -488,6 +489,12 @@ namespace ItemDisplay {
 			}
 			if (without_invis_chars(r->action.name).length() > 0) {
 				NameRuleList.push_back(r);
+				// this is a bit of a hack. the idea is not to block items that have a name specified. Items with a map action are
+				// already not blocked, so we make another rule list for those with a name and not a map action. Note the name must
+				// not use CONTINUE. If item display line uses continue, then the item can still be blocked by a matching ignore
+				// item display line.
+				if (r->action.stopProcessing && !has_map_action)
+					DoNotBlockRuleList.push_back(r); // if we have a non-blank name and no continue, we don't want to block
 				has_name = true;
 			}
 			if (!has_map_action && !has_name && !has_desc && r->action.stopProcessing) {
@@ -516,6 +523,7 @@ namespace ItemDisplay {
 		NameRuleList.clear();
 		DescRuleList.clear();
 		MapRuleList.clear();
+		DoNotBlockRuleList.clear();
 		IgnoreRuleList.clear();
 	}
 }

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -205,7 +205,8 @@ string ItemNameLookupCache::make_cached_T(UnitItemInfo *uInfo, const string &nam
 			}
 					
 		}
-		if (!has_map_action) return new_name + " [blocked]";
+		bool whitelisted = do_not_block_cache.Get(uInfo);
+		if (!has_map_action && !whitelisted) return new_name + " [blocked]";
 	}
 	return new_name;
 }
@@ -255,6 +256,7 @@ string IgnoreLookupCache::to_str(const bool &ignore) {
 ItemDescLookupCache item_desc_cache(DescRuleList);
 ItemNameLookupCache item_name_cache(NameRuleList);
 MapActionLookupCache map_action_cache(MapRuleList);
+IgnoreLookupCache do_not_block_cache(DoNotBlockRuleList);
 IgnoreLookupCache ignore_cache(IgnoreRuleList);
 
 void GetItemName(UnitItemInfo *uInfo, string &name) {
@@ -454,6 +456,7 @@ namespace ItemDisplay {
 		item_desc_cache.ResetCache();
 		item_name_cache.ResetCache();
 		map_action_cache.ResetCache();
+		do_not_block_cache.ResetCache();
 		ignore_cache.ResetCache();
 		BH::config->ReadMapList("ItemDisplay", rules);
 		for (unsigned int i = 0; i < rules.size(); i++) {
@@ -518,6 +521,7 @@ namespace ItemDisplay {
 		item_desc_cache.ResetCache();
 		item_name_cache.ResetCache();
 		map_action_cache.ResetCache();
+		do_not_block_cache.ResetCache();
 		ignore_cache.ResetCache();
 		RuleList.clear();
 		NameRuleList.clear();

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -524,6 +524,7 @@ struct SkillReplace {
 struct Action {
 	bool stopProcessing;
 	string name;
+	string description;
 	int colorOnMap;
 	int borderColor;
 	int dotColor;
@@ -538,7 +539,8 @@ struct Action {
 		lineColor(UNDEFINED_COLOR),
 		notifyColor(UNDEFINED_COLOR),
 		stopProcessing(true),
-		name("") {}
+		name(""),
+		description("") {}
 };
 
 struct Rule {
@@ -631,6 +633,7 @@ namespace ItemDisplay {
 }
 StatProperties *GetStatProperties(unsigned int stat);
 void BuildAction(string *str, Action *act);
+string ParseDescription(Action *act);
 int ParseMapColor(Action *act, const string& reg_string);
 void HandleUnknownItemCode(char *code, char *tag);
 BYTE GetOperation(string *op);

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -629,13 +629,25 @@ class MapActionLookupCache : public RuleLookupCache<vector<Action>> {
 			RuleLookupCache<vector<Action>>(RuleList) {}
 };
 
+class IgnoreLookupCache : public RuleLookupCache<bool> {
+	bool make_cached_T(UnitItemInfo *uInfo) override;
+	string to_str(const bool &ignore);
+
+		public:
+		IgnoreLookupCache(const std::vector<Rule*> &RuleList) :
+			RuleLookupCache<bool>(RuleList) {}
+};
+
 extern vector<Rule*> RuleList;
+extern vector<Rule*> NameRuleList;
+extern vector<Rule*> DescRuleList;
 extern vector<Rule*> MapRuleList;
 extern vector<Rule*> IgnoreRuleList;
 extern vector<pair<string, string>> rules;
 extern ItemDescLookupCache item_desc_cache;
 extern ItemNameLookupCache item_name_cache;
 extern MapActionLookupCache map_action_cache;
+extern IgnoreLookupCache ignore_cache;
 
 namespace ItemDisplay {
 	void InitializeItemRules();

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -642,6 +642,7 @@ extern vector<Rule*> RuleList;
 extern vector<Rule*> NameRuleList;
 extern vector<Rule*> DescRuleList;
 extern vector<Rule*> MapRuleList;
+extern vector<Rule*> DoNotBlockRuleList;
 extern vector<Rule*> IgnoreRuleList;
 extern vector<pair<string, string>> rules;
 extern ItemDescLookupCache item_desc_cache;

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -648,6 +648,7 @@ extern vector<pair<string, string>> rules;
 extern ItemDescLookupCache item_desc_cache;
 extern ItemNameLookupCache item_name_cache;
 extern MapActionLookupCache map_action_cache;
+extern IgnoreLookupCache do_not_block_cache;
 extern IgnoreLookupCache ignore_cache;
 
 namespace ItemDisplay {

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -602,6 +602,15 @@ struct Rule {
 	}
 };
 
+class ItemDescLookupCache : public RuleLookupCache<string> {
+	string make_cached_T(UnitItemInfo *uInfo) override;
+	string to_str(const string &name) override;
+
+		public:
+		ItemDescLookupCache(const std::vector<Rule*> &RuleList) :
+			RuleLookupCache<string>(RuleList) {}
+};
+
 class ItemNameLookupCache : public RuleLookupCache<string, const string &> {
 	string make_cached_T(UnitItemInfo *uInfo, const string &name) override;
 	string to_str(const string &name) override;
@@ -624,6 +633,7 @@ extern vector<Rule*> RuleList;
 extern vector<Rule*> MapRuleList;
 extern vector<Rule*> IgnoreRuleList;
 extern vector<pair<string, string>> rules;
+extern ItemDescLookupCache item_desc_cache;
 extern ItemNameLookupCache item_name_cache;
 extern MapActionLookupCache map_action_cache;
 
@@ -639,7 +649,7 @@ void HandleUnknownItemCode(char *code, char *tag);
 BYTE GetOperation(string *op);
 inline bool IntegerCompare(unsigned int Lvalue, int operation, unsigned int Rvalue);
 void GetItemName(UnitItemInfo *uInfo, string &name);
-void SubstituteNameVariables(UnitItemInfo *uInfo, string &name, Action *action);
+void SubstituteNameVariables(UnitItemInfo *uInfo, string &name, const string &action_name);
 int GetDefense(ItemInfo *item);
 BYTE GetAffixLevel(BYTE ilvl, BYTE qlvl, BYTE mlvl);
 BYTE GetRequiredLevel(UnitAny* item);

--- a/BH/Modules/ItemMover/ItemMover.cpp
+++ b/BH/Modules/ItemMover/ItemMover.cpp
@@ -582,6 +582,7 @@ void ItemMover::OnGamePacketRecv(BYTE* packet, bool* block) {
 				//PrintText(1, "Item packet: %s, %s, %X, %d, %d", item.name.c_str(), item.code, item.attrs->flags, item.sockets, GetDefense(&item));
 				if ((item.action == ITEM_ACTION_NEW_GROUND || item.action == ITEM_ACTION_OLD_GROUND) && success) {
 					bool showOnMap = false;
+					bool nameWhitelisted = false;
 					auto color = UNDEFINED_COLOR;
 
 					for (vector<Rule*>::iterator it = MapRuleList.begin(); it != MapRuleList.end(); it++) {
@@ -591,6 +592,12 @@ void ItemMover::OnGamePacketRecv(BYTE* packet, bool* block) {
 							// if we leave this break here, we can't set notify colors as nicely
 							// for multiline 'building' configs
 							/* break; */
+						}
+					}
+					// Don't block items that have a white-listed name
+					for (vector<Rule*>::iterator it = DoNotBlockRuleList.begin(); it != DoNotBlockRuleList.end(); it++) {
+						if ((*it)->Evaluate(NULL, &item)) {
+							nameWhitelisted = true;
 						}
 					}
 					//PrintText(1, "Item on ground: %s, %s, %s, %X", item.name.c_str(), item.code, item.attrs->category.c_str(), item.attrs->flags);
@@ -617,7 +624,7 @@ void ItemMover::OnGamePacketRecv(BYTE* packet, bool* block) {
 									);
 						}
 					}
-					else if (!showOnMap) {
+					else if (!showOnMap && !nameWhitelisted) {
 						for (vector<Rule*>::iterator it = IgnoreRuleList.begin(); it != IgnoreRuleList.end(); it++) {
 							if ((*it)->Evaluate(NULL, &item)) {
 								*block = true;

--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ Mustache[header]: {{>header-unique}}{{>header-magic}}{{>header-else}}{{#count}} 
 Mustache[item]: {{>header}}{{>stats}}{{^isRuneword}}{{#socketed}}\n\n  * {{>>item}}{{/socketed}}{{/isRuneword}}\n
 Mustache[stash]: {{#this}}* {{>item}}\n\n{{/this}}
 ```
+
+# Release Notes for 1.9.9-b1
+* Adds support for a configurable item description field. The description goes in curly braces `{}`. "Advanced Item Display" must be on for the description to show. For example, you can add a hint to ebug armors with the following.
+```ItemDisplay[!RW ETH !SUP CHEST NMAG SOCK=0]: %NAME%{%WHITE%Add sockets in cube with Tal+Thul+%YELLOW%o%WHITE%Perfect}
+```
+* The item description field supports the same keywords as the normal item name, so `%ILVL%` will work as expected, for example. 
+* The `%NAME%` keyword behaves much the same way as well, except that it will insert the previous *description*, not the item's name. This only make sense when `%CONTINUE%` is used. The result of the following is that an ebug-eligible armor with 667+ defense will display "A good EBUG base. Add sockets...". If `%NAME%` is used without a description being set on another matching `ItemDisplay` line first, it will resolve to a blank string.
+```ItemDisplay[!RW ETH !SUP CHEST NMAG SOCK=0 DEF>666]: %NAME%{%WHITE% A good EBUG base.}%CONTINUE%
+ItemDisplay[!RW ETH !SUP CHEST NMAG SOCK=0]: %NAME%{%NAME% %WHITE%Add sockets in cube with Tal+Thul+%YELLOW%O%WHITE%Perfect}```
+* The item level and affix level can now be displayed as part of the item's properties (like required level, durability, etc.). To enable this, "Advanced Item Display" and "Show iLvl" must be on.
+
 # Release Notes for 1.9.8
 ## Bug fixes
 * `BOW` and `SCEPTER` item groups now work correctly

--- a/README.md
+++ b/README.md
@@ -65,13 +65,16 @@ Mustache[stash]: {{#this}}* {{>item}}\n\n{{/this}}
 ```
 
 # Release Notes for 1.9.9-b1
-* Adds support for a configurable item description field. The description goes in curly braces `{}`. "Advanced Item Display" must be on for the description to show. For example, you can add a hint to ebug armors with the following.
-```ItemDisplay[!RW ETH !SUP CHEST NMAG SOCK=0]: %NAME%{%WHITE%Add sockets in cube with Tal+Thul+%YELLOW%o%WHITE%Perfect}
+* Adds support for a configurable item description field. This field is shown in game along with the item properties (like required level, durability, etc.). It's useful for information you want to display with the item that doesn't need to be part of the item's name. The description goes in curly braces `{}`. "Advanced Item Display" must be on for the description to show. For example, you can add a hint to ebug armors with the following. [more info](https://github.com/planqi/slashdiablo-maphack/pull/46)
+```
+ItemDisplay[!RW ETH !SUP CHEST NMAG SOCK=0]: %NAME%{%WHITE%Add sockets in cube with Tal+Thul+%YELLOW%o%WHITE%Perfect}
 ```
 * The item description field supports the same keywords as the normal item name, so `%ILVL%` will work as expected, for example. 
-* The `%NAME%` keyword behaves much the same way as well, except that it will insert the previous *description*, not the item's name. This only make sense when `%CONTINUE%` is used. The result of the following is that an ebug-eligible armor with 667+ defense will display "A good EBUG base. Add sockets...". If `%NAME%` is used without a description being set on another matching `ItemDisplay` line first, it will resolve to a blank string.
-```ItemDisplay[!RW ETH !SUP CHEST NMAG SOCK=0 DEF>666]: %NAME%{%WHITE% A good EBUG base.}%CONTINUE%
-ItemDisplay[!RW ETH !SUP CHEST NMAG SOCK=0]: %NAME%{%NAME% %WHITE%Add sockets in cube with Tal+Thul+%YELLOW%O%WHITE%Perfect}```
+* The `%NAME%` keyword behaves much the same way as well, except that when in curly braces `{}`, it will insert the previous *description*, not the item's name. This only make sense when `%CONTINUE%` is used. The result of the following is that an ebug-eligible armor with 667+ defense will display "A good EBUG base. Add sockets...". If `%NAME%` is used without a description being set on another matching `ItemDisplay` line first, it will resolve to a blank string. There are no changes to how `%NAME%` works outside curly braces `{}`.
+```
+ItemDisplay[!RW ETH !SUP CHEST NMAG SOCK=0 DEF>666]: %NAME%{%WHITE% A good EBUG base.}%CONTINUE%
+ItemDisplay[!RW ETH !SUP CHEST NMAG SOCK=0]: %NAME%{%NAME% %WHITE%Add sockets in cube with Tal+Thul+%YELLOW%O%WHITE%Perfect}
+```
 * The item level and affix level can now be displayed as part of the item's properties (like required level, durability, etc.). To enable this, "Advanced Item Display" and "Show iLvl" must be on.
 
 # Release Notes for 1.9.8


### PR DESCRIPTION
This PR includes #46 (otherwise there may be conflicts when merging later). I tested this only on a couple items so far using the example situations below.

This change impacts the priority of display rules that set item names vs. block them. Item display lines that set a name without the use of `%CONTINUE%` will take priority over blocking lines after this change. This makes it easier to white-list items without causing them to be drawn on the map or generate a notification. Here are some examples.

Below, **Before** refers to behavior before this change (1.9.8). **After** is behavior after this change.

```
ItemDisplay[blah]: %NAME%
ItemDisplay[blah]:
```
**Before:** Item is blocked.
**After:** Item is displayed.

---
```
ItemDisplay[blah]: %NAME%%CONTINUE%
ItemDisplay[blah]:
```
**Before:** Item is blocked.
**After:** Item is blocked.

---
```
ItemDisplay[blah]: %NAME%%MAP%
ItemDisplay[blah]:
```
**Before:** Item is displayed and pinged.
**After:** Item is displayed and pinged.

---
```
ItemDisplay[blah]: %NAME%%MAP%%CONTINUE%
ItemDisplay[blah]:
```
**Before:** Item is displayed and pinged.
**After:** Item is displayed and pinged.