### PR TITLE
Center skill warning

### DIFF
--- a/BH/Modules/AutoTele/AutoTele.cpp
+++ b/BH/Modules/AutoTele/AutoTele.cpp
@@ -2,7 +2,6 @@
 #include "../../BH.h"
 #include "ATIncludes\CMapIncludes.h"
 #include "ATIncludes\Vectors.h"
-#include "../ScreenInfo/ScreenInfo.h"
 
 #define VALIDPTR(x) ( (x) && (!IsBadReadPtr(x,sizeof(x))) )
 
@@ -30,9 +29,6 @@ void AutoTele::OnLoad() {
 
 	new Checkhook(settingsTab, col, (Y += 15),
 			&Toggles["Quest Drop Warning"].state, "Quest Drop Warning");
-
-	new Checkhook(settingsTab, col, (Y += 15),
-			&(ScreenInfo::Toggles)["Center Skill Warning"].state, "Center Skill Warning");
 
 	new Texthook(settingsTab, col+20, (Y += 22), "Game creation");
 	new Checkhook(settingsTab, col, (Y += 15),

--- a/BH/Modules/AutoTele/AutoTele.cpp
+++ b/BH/Modules/AutoTele/AutoTele.cpp
@@ -2,6 +2,7 @@
 #include "../../BH.h"
 #include "ATIncludes\CMapIncludes.h"
 #include "ATIncludes\Vectors.h"
+#include "../ScreenInfo/ScreenInfo.h"
 
 #define VALIDPTR(x) ( (x) && (!IsBadReadPtr(x,sizeof(x))) )
 
@@ -29,6 +30,9 @@ void AutoTele::OnLoad() {
 
 	new Checkhook(settingsTab, col, (Y += 15),
 			&Toggles["Quest Drop Warning"].state, "Quest Drop Warning");
+
+	new Checkhook(settingsTab, col, (Y += 15),
+			&(ScreenInfo::Toggles)["Center Skill Warning"].state, "Center Skill Warning");
 
 	new Texthook(settingsTab, col+20, (Y += 22), "Game creation");
 	new Checkhook(settingsTab, col, (Y += 15),

--- a/BH/Modules/ScreenInfo/ScreenInfo.cpp
+++ b/BH/Modules/ScreenInfo/ScreenInfo.cpp
@@ -35,8 +35,6 @@ void ScreenInfo::LoadConfig() {
 
 	BH::config->ReadArray("AutomapInfo", automapInfo);
 
-	BH::config->ReadToggle("Center Skill Warning", "None", false, Toggles["Center Skill Warning"]);
-
 	BH::config->ReadAssoc("Skill Warning", SkillWarnings);
 	SkillWarningMap.clear();
 	for (auto it = SkillWarnings.cbegin(); it != SkillWarnings.cend(); it++) {
@@ -183,13 +181,7 @@ void ScreenInfo::OnDraw() {
 	}
 
 	for (std::deque<StateWarning*>::iterator it = CurrentWarnings.begin(); it != CurrentWarnings.end(); ++it) {
-		unsigned int posX = 400;
-		unsigned int posY = 30 * (yOffset++);
-		if (Toggles["Center Skill Warning"].state) {
-			posX = *p_D2CLIENT_ScreenSizeX / 2;
-			posY = *p_D2CLIENT_ScreenSizeY / 2;
-		}
-		Texthook::Draw(posX, posY, Center, 3, Red, "%s has expired!", (*it)->name.c_str());
+		Texthook::Draw(400, 30 * (yOffset++), Center, 3, Red, "%s has expired!", (*it)->name.c_str());
 	}
 
 	// It's a kludge to peek into other modules for config info, but it just seems silly to

--- a/BH/Modules/ScreenInfo/ScreenInfo.cpp
+++ b/BH/Modules/ScreenInfo/ScreenInfo.cpp
@@ -35,6 +35,8 @@ void ScreenInfo::LoadConfig() {
 
 	BH::config->ReadArray("AutomapInfo", automapInfo);
 
+	BH::config->ReadToggle("Center Skill Warning", "None", false, Toggles["Center Skill Warning"]);
+
 	BH::config->ReadAssoc("Skill Warning", SkillWarnings);
 	SkillWarningMap.clear();
 	for (auto it = SkillWarnings.cbegin(); it != SkillWarnings.cend(); it++) {
@@ -181,7 +183,13 @@ void ScreenInfo::OnDraw() {
 	}
 
 	for (std::deque<StateWarning*>::iterator it = CurrentWarnings.begin(); it != CurrentWarnings.end(); ++it) {
-		Texthook::Draw(400, 30 * (yOffset++), Center, 3, Red, "%s has expired!", (*it)->name.c_str());
+		unsigned int posX = 400;
+		unsigned int posY = 30 * (yOffset++);
+		if (Toggles["Center Skill Warning"].state) {
+			posX = *p_D2CLIENT_ScreenSizeX / 2;
+			posY = *p_D2CLIENT_ScreenSizeY / 2;
+		}
+		Texthook::Draw(posX, posY, Center, 3, Red, "%s has expired!", (*it)->name.c_str());
 	}
 
 	// It's a kludge to peek into other modules for config info, but it just seems silly to

--- a/BH/Modules/ScreenInfo/ScreenInfo.cpp
+++ b/BH/Modules/ScreenInfo/ScreenInfo.cpp
@@ -181,7 +181,9 @@ void ScreenInfo::OnDraw() {
 	}
 
 	for (std::deque<StateWarning*>::iterator it = CurrentWarnings.begin(); it != CurrentWarnings.end(); ++it) {
-		Texthook::Draw(400, 30 * (yOffset++), Center, 3, Red, "%s has expired!", (*it)->name.c_str());
+		unsigned int posX = *p_D2CLIENT_ScreenSizeX / 2;
+		unsigned int posY = *p_D2CLIENT_ScreenSizeY / 2;;
+		Texthook::Draw(posX, posY, Center, 3, Red, "%s has expired!", (*it)->name.c_str());
 	}
 
 	// It's a kludge to peek into other modules for config info, but it just seems silly to


### PR DESCRIPTION
Added both in the settings file and the UI.

The default warning goes at the top left corner and I often miss it, since I'm playing with a higher resolution. I added this as an option as to not disrupt the current behavior.

<details>
  <summary>Example:</summary>

  UI:
  ![Game_npRaDZPBLY](https://user-images.githubusercontent.com/1731173/82476812-f3928000-9aa4-11ea-856f-b5e4470735db.png)

  Centered warning:
  ![Game_PDGkyf5pun](https://user-images.githubusercontent.com/1731173/82476480-8848ae00-9aa4-11ea-9765-6c2fb33f5b8c.png)
</summary>