### PR TITLE
enhancements to screeninfo

### DIFF
--- a/BH/BH.vcxproj
+++ b/BH/BH.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -17,28 +17,27 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{E549AF63-EF8D-4054-A95B-9C4AE6F51029}</ProjectGuid>
     <RootNamespace>BH</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Packaging|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v120</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/BH/BH.vcxproj
+++ b/BH/BH.vcxproj
@@ -80,6 +80,12 @@
       <ModuleDefinitionFile>
       </ModuleDefinitionFile>
     </Link>
+    <PostBuildEvent>
+      <Command>set "D2Path=$(D2Path)"
+if defined D2Path (
+    xcopy "$(SolutionDir)$(Configuration)" "$(D2Path)" /h /i /c /k /e /r /y
+)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -98,6 +104,12 @@
       <ModuleDefinitionFile>
       </ModuleDefinitionFile>
     </Link>
+    <PostBuildEvent>
+      <Command>set "D2Path=$(D2Path)"
+if defined D2Path (
+    xcopy "$(SolutionDir)$(Configuration)" "$(D2Path)" /h /i /c /k /e /r /y
+)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Packaging|Win32'">
     <ClCompile>
@@ -114,6 +126,12 @@
       <ModuleDefinitionFile>
       </ModuleDefinitionFile>
     </Link>
+    <PostBuildEvent>
+      <Command>set "D2Path=$(D2Path)"
+if defined D2Path (
+    xcopy "$(SolutionDir)$(Configuration)" "$(D2Path)" /h /i /c /k /e /r /y
+)</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="AsyncDrawBuffer.cpp" />

--- a/BH/Modules/ScreenInfo/ScreenInfo.cpp
+++ b/BH/Modules/ScreenInfo/ScreenInfo.cpp
@@ -72,6 +72,10 @@ void ScreenInfo::OnGameJoin() {
 	gameTimer = GetTickCount();
 	UnitAny* pUnit = D2CLIENT_GetPlayerUnit();
 	startExperience = (int)D2COMMON_GetUnitStat(pUnit, STAT_EXP, 0);
+	if (currentPlayer.compare(0, 16, pUnit->pPlayerData->szName) != 0) {
+		gamesToLevel = std::numeric_limits<double>::infinity();
+	}
+	currentPlayer = string(pUnit->pPlayerData->szName);
 	startLevel = (int)D2COMMON_GetUnitStat(pUnit, STAT_LEVEL, 0);
 }
 

--- a/BH/Modules/ScreenInfo/ScreenInfo.cpp
+++ b/BH/Modules/ScreenInfo/ScreenInfo.cpp
@@ -32,6 +32,7 @@ void ScreenInfo::OnLoad() {
 	lastExpPerSecond = 0.0;
 	lastExpGainPct = 0.0;
 	lastExpPerSecondUnit = "";
+	lastGameLength = 0;
 }
 
 void ScreenInfo::LoadConfig() {
@@ -80,6 +81,7 @@ void ScreenInfo::OnGameJoin() {
 		lastExpPerSecond = 0.0;
 		lastExpGainPct = 0.0;
 		lastExpPerSecondUnit = "";
+		lastGameLength = 0;
 	}
 	currentPlayer = string(pUnit->pPlayerData->szName);
 	startLevel = (int)D2COMMON_GetUnitStat(pUnit, STAT_LEVEL, 0);
@@ -292,14 +294,18 @@ void ScreenInfo::OnAutomapDraw() {
 	CHAR szPing[10] = "";
 	sprintf_s(szPing, sizeof(szPing), "%d", *p_D2CLIENT_Ping);
 
-	CHAR szGamesToLevel[128] = "";
+	CHAR szGamesToLevel[32] = "";
 	sprintf_s(szGamesToLevel, sizeof(szGamesToLevel), "%.2f", gamesToLevel);
 	
-	CHAR szLastXpGainPer[128] = "";
+	CHAR szLastXpGainPer[32] = "";
 	sprintf_s(szLastXpGainPer, sizeof(szLastXpGainPer), "%s%00.2f%%", lastExpGainPct >= 0 ? "+" : "", lastExpGainPct);
 
-	CHAR szLastXpPerSec[128] = "";
+	CHAR szLastXpPerSec[32] = "";
 	sprintf_s(szLastXpPerSec, sizeof(szLastXpPerSec), "%s%.2f%s/s", lastExpPerSecond >= 0 ? "+" : "", lastExpPerSecond, lastExpPerSecondUnit);
+
+	char lastGameTime[20];
+	nTime = (lastGameLength/ 1000);
+	sprintf_s(lastGameTime, 20, "%.2d:%.2d:%.2d", nTime / 3600, (nTime / 60) % 60, nTime % 60);
 
 	AutomapReplace automap[] = {
 		{"GAMENAME", pData->szGameName},
@@ -314,7 +320,8 @@ void ScreenInfo::OnAutomapDraw() {
 		{"REALTIME", szTime},
 		{"GAMESTOLVL", szGamesToLevel},
 		{"LASTXPPERCENT", szLastXpGainPer},
-		{"LASTXPPERSEC", szLastXpPerSec}
+		{"LASTXPPERSEC", szLastXpPerSec},
+		{"LASTGAMETIME", lastGameTime}
 	};
 
 	for (vector<string>::iterator it = automapInfo.begin(); it < automapInfo.end(); it++) {
@@ -415,6 +422,7 @@ void ScreenInfo::OnGameExit() {
 	lastExpGainPct = currentExpGainPct;
 	lastExpPerSecond = currentExpPerSecond;
 	lastExpPerSecondUnit = currentExpPerSecondUnit;
+	lastGameLength = GetTickCount() - gameTimer;
 
 	MephistoBlocked = false;
 	DiabloBlocked = false;

--- a/BH/Modules/ScreenInfo/ScreenInfo.h
+++ b/BH/Modules/ScreenInfo/ScreenInfo.h
@@ -45,14 +45,14 @@ class ScreenInfo : public Module {
 		string currentPlayer;
 		DWORD currentExperience;
 		int currentLevel;
-		double gamesToLevel;
-		ULONGLONG timeToLevel;
 		double currentExpGainPct;
 		double currentExpPerSecond;
 		char* currentExpPerSecondUnit;
-		double lastExpGainPct;
-		double lastExpPerSecond;
-		ULONGLONG lastGameLength;
+		string szGamesToLevel;
+		string szTimeToLevel;
+		string szLastXpGainPer;
+		string szLastXpPerSec;
+		string szLastGameTime;
 
 		void ScreenInfo::FormattedXPPerSec(char* buffer, double xpPerSec);
 	public:

--- a/BH/Modules/ScreenInfo/ScreenInfo.h
+++ b/BH/Modules/ScreenInfo/ScreenInfo.h
@@ -42,6 +42,9 @@ class ScreenInfo : public Module {
 		bool ReceivedQuestPacket;
 		DWORD startExperience;
 		int startLevel;
+		DWORD currentExperience;
+		int currentLevel;
+		double gamesToLevel;
 
 		void ScreenInfo::drawExperienceInfo();
 	public:

--- a/BH/Modules/ScreenInfo/ScreenInfo.h
+++ b/BH/Modules/ScreenInfo/ScreenInfo.h
@@ -42,6 +42,7 @@ class ScreenInfo : public Module {
 		bool ReceivedQuestPacket;
 		DWORD startExperience;
 		int startLevel;
+		string currentPlayer;
 		DWORD currentExperience;
 		int currentLevel;
 		double gamesToLevel;

--- a/BH/Modules/ScreenInfo/ScreenInfo.h
+++ b/BH/Modules/ScreenInfo/ScreenInfo.h
@@ -46,15 +46,15 @@ class ScreenInfo : public Module {
 		DWORD currentExperience;
 		int currentLevel;
 		double gamesToLevel;
+		ULONGLONG timeToLevel;
 		double currentExpGainPct;
 		double currentExpPerSecond;
 		char* currentExpPerSecondUnit;
 		double lastExpGainPct;
 		double lastExpPerSecond;
-		char* lastExpPerSecondUnit;
 		ULONGLONG lastGameLength;
 
-		void ScreenInfo::drawExperienceInfo();
+		void ScreenInfo::FormattedXPPerSec(char* buffer, double xpPerSec);
 	public:
 		static map<std::string, Toggle> Toggles;
 

--- a/BH/Modules/ScreenInfo/ScreenInfo.h
+++ b/BH/Modules/ScreenInfo/ScreenInfo.h
@@ -46,6 +46,12 @@ class ScreenInfo : public Module {
 		DWORD currentExperience;
 		int currentLevel;
 		double gamesToLevel;
+		double currentExpGainPct;
+		double currentExpPerSecond;
+		char* currentExpPerSecondUnit;
+		double lastExpGainPct;
+		double lastExpPerSecond;
+		char* lastExpPerSecondUnit;
 
 		void ScreenInfo::drawExperienceInfo();
 	public:

--- a/BH/Modules/ScreenInfo/ScreenInfo.h
+++ b/BH/Modules/ScreenInfo/ScreenInfo.h
@@ -52,6 +52,7 @@ class ScreenInfo : public Module {
 		double lastExpGainPct;
 		double lastExpPerSecond;
 		char* lastExpPerSecondUnit;
+		ULONGLONG lastGameLength;
 
 		void ScreenInfo::drawExperienceInfo();
 	public:


### PR DESCRIPTION
Adds the following automap info keys.

`GAMESTOLVL`: estimated # of games needed to play for the next level. calculated off the amount of xp gained from your previous run.
`TIMETOLVL`: hh:mm:ss estimate to level based on the same stats as above.
`LASTXPPERCENT`: % xp you gained in the last game.
`LASTXPPERSEC`: % xp per sec of your last game.
`LASTGAMETIME`: time your last run took.

![image](https://user-images.githubusercontent.com/1458109/82836589-c5da7c00-9e94-11ea-989c-0427c209b776.png)



Also this branch adds a post build event to copy the dll/pbd/other built resources to your D2 directory if you set the environment variable `D2Path`. If the env variable is undefined nothing new happens.