### PR TITLE
Feature/permanently show items

### DIFF
--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -143,6 +143,25 @@ void Item::LoadConfig() {
 	BH::config->ReadKey("Show Players Gear", "VK_0", showPlayer);
 }
 
+void Item::ResetPatches() {
+	//todo figure out a way to not have to install/remove the patches onloop
+	//we only remove it because one of them will break being able to not
+	//target monsters with your normal show items key.
+	if (Toggles["Always Show Items"].state) {
+		permShowItems1->Install();
+		permShowItems2->Install();
+		permShowItems3->Install();
+		permShowItems4->Install();
+		permShowItems5->Install();
+	} else {
+		permShowItems1->Remove();
+		permShowItems2->Remove();
+		permShowItems3->Remove();
+		permShowItems4->Remove();
+		permShowItems5->Remove();
+	}
+}
+
 void Item::DrawSettings() {
 	settingsTab = new UITab("Item", BH::settingsUI);
 	int y = 10;
@@ -250,6 +269,7 @@ void Item::OnUnload() {
 }
 
 void Item::OnLoop() {
+	ResetPatches();
 	static unsigned int localFilterLevel = 0;
 	static unsigned int localPingLevel = 0;
 	// This is a bit of a hack to reset the cache when the user changes the item filter level
@@ -1308,6 +1328,10 @@ BOOL Item::PermShowItemsPatch1()
 }
 
 //these two seem to deal w/ fixing the inv/waypoints when alt is down
+//one of them breaks being able to not hover monsters when holding alt
+//e.g. if ur wwing as a barb and dont want to lock a monster u usually hold
+//alt (or space or whatever u have show items bound to). this is broken with
+//these patches.
 BOOL Item::PermShowItemsPatch2() {
 	return Toggles["Always Show Items"].state || D2CLIENT_GetUIState(UI_GROUND_ITEMS);
 }

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -69,6 +69,13 @@ Patch* viewInvPatch1 = new Patch(Call, D2CLIENT, { 0x953E2, 0x997B2 }, (int)View
 Patch* viewInvPatch2 = new Patch(Call, D2CLIENT, { 0x94AB4, 0x98E84 }, (int)ViewInventoryPatch2_ASM, 6);
 Patch* viewInvPatch3 = new Patch(Call, D2CLIENT, { 0x93A6F, 0x97E3F }, (int)ViewInventoryPatch3_ASM, 5);
 
+//ported to 1.13c/d from https://github.com/jieaido/d2hackmap/blob/master/PermShowItem.cpp
+Patch* permShowItems1 = new Patch(Call, D2CLIENT, { 0xC3D4E, 0x1D74E }, (int)PermShowItemsPatch1_ASM, 6);
+Patch* permShowItems2 = new Patch(Call, D2CLIENT, { 0xC0E9A, 0x1A89A }, (int)PermShowItemsPatch1_ASM, 6);
+Patch* permShowItems3 = new Patch(Call, D2CLIENT, { 0x59483, 0x4EA13 }, (int)PermShowItemsPatch2_ASM, 6);
+Patch* permShowItems4 = new Patch(Call, D2CLIENT, { 0x5908A, 0x4E61A }, (int)PermShowItemsPatch3_ASM, 6);
+Patch* permShowItems5 = new Patch(Call, D2CLIENT, { 0xA6BA3, 0x63443 }, (int)PermShowItemsPatch4_ASM, 6);
+
 using namespace Drawing;
 
 void Item::OnLoad() {
@@ -77,6 +84,12 @@ void Item::OnLoad() {
 	viewInvPatch1->Install();
 	viewInvPatch2->Install();
 	viewInvPatch3->Install();
+
+	permShowItems1->Install();
+	permShowItems2->Install();
+	permShowItems3->Install();
+	permShowItems4->Install();
+	permShowItems5->Install();
 
 	itemPropertiesPatch->Install();
 	itemPropertyStringDamagePatch->Install();
@@ -111,6 +124,7 @@ void Item::LoadConfig() {
 	BH::config->ReadToggle("Alt Item Style", "None", true, Toggles["Alt Item Style"]);
 	BH::config->ReadToggle("Color Mod", "None", false, Toggles["Color Mod"]);
 	BH::config->ReadToggle("Shorten Item Names", "None", false, Toggles["Shorten Item Names"]);
+	BH::config->ReadToggle("Always Show Items", "None", false, Toggles["Always Show Items"]);
 	BH::config->ReadToggle("Advanced Item Display", "None", false, Toggles["Advanced Item Display"]);
 	BH::config->ReadToggle("Item Drop Notifications", "None", false, Toggles["Item Drop Notifications"]);
 	BH::config->ReadToggle("Item Close Notifications", "None", false, Toggles["Item Close Notifications"]);
@@ -160,6 +174,10 @@ void Item::DrawSettings() {
 
 	new Checkhook(settingsTab, 4, y, &Toggles["Shorten Item Names"].state, "Shorten Names");
 	new Keyhook(settingsTab, keyhook_x, y+2, &Toggles["Shorten Item Names"].toggle, "");
+	y += 15;
+
+	new Checkhook(settingsTab, 4, y, &Toggles["Always Show Items"].state, "Always Show Items");
+	new Keyhook(settingsTab, keyhook_x, y + 2, &Toggles["Always Show Items"].toggle, "");
 	y += 15;
 
 	new Checkhook(settingsTab, 4, y, &Toggles["Always Show Item Stat Ranges"].state, "Always Show Item Stat Ranges");
@@ -223,6 +241,11 @@ void Item::OnUnload() {
 	viewInvPatch1->Remove();
 	viewInvPatch2->Remove();
 	viewInvPatch3->Remove();
+	permShowItems1->Remove();
+	permShowItems2->Remove();
+	permShowItems3->Remove();
+	permShowItems4->Remove();
+	permShowItems5->Remove();
 	ItemDisplay::UninitializeItemRules();
 }
 
@@ -321,17 +344,17 @@ void __fastcall Item::ItemNamePatch(wchar_t *name, UnitAny *item)
 	}
 
 	// Some common color codes for text strings (see TextColor enum):
-	// ÿc; (purple)
-	// ÿc0 (white)
-	// ÿc1 (red)
-	// ÿc2 (green)
-	// ÿc3 (blue)
-	// ÿc4 (gold)
-	// ÿc5 (gray)
-	// ÿc6 (black)
-	// ÿc7 (tan)
-	// ÿc8 (orange)
-	// ÿc9 (yellow)
+	// Ã¿c; (purple)
+	// Ã¿c0 (white)
+	// Ã¿c1 (red)
+	// Ã¿c2 (green)
+	// Ã¿c3 (blue)
+	// Ã¿c4 (gold)
+	// Ã¿c5 (gray)
+	// Ã¿c6 (black)
+	// Ã¿c7 (tan)
+	// Ã¿c8 (orange)
+	// Ã¿c9 (yellow)
 
 	/* Test code to display item codes */
 	//string test3 = test_code;
@@ -350,12 +373,12 @@ void Item::OrigGetItemName(UnitAny *item, string &itemName, char *code)
 		// We will also strip ilvls from these items
 		if (code[0] == 't' && code[1] == 's' && code[2] == 'c')  // town portal scroll
 		{
-			itemName = "ÿc2**ÿc0TP";
+			itemName = "Ã¿c2**Ã¿c0TP";
 			displayItemLevel = false;
 		}
 		else if (code[0] == 'i' && code[1] == 's' && code[2] == 'c')  // identify scroll
 		{
-			itemName = "ÿc2**ÿc0ID";
+			itemName = "Ã¿c2**Ã¿c0ID";
 			displayItemLevel = false;
 		}
 		else if (code[0] == 'v' && code[1] == 'p' && code[2] == 's')  // stamina potion
@@ -407,27 +430,27 @@ void Item::OrigGetItemName(UnitAny *item, string &itemName, char *code)
 		{
 			if (code[2] == '1')
 			{
-				itemName = "ÿc1**ÿc0Min Heal";
+				itemName = "Ã¿c1**Ã¿c0Min Heal";
 				displayItemLevel = false;
 			}
 			else if (code[2] == '2')
 			{
-				itemName = "ÿc1**ÿc0Lt Heal";
+				itemName = "Ã¿c1**Ã¿c0Lt Heal";
 				displayItemLevel = false;
 			}
 			else if (code[2] == '3')
 			{
-				itemName = "ÿc1**ÿc0Heal";
+				itemName = "Ã¿c1**Ã¿c0Heal";
 				displayItemLevel = false;
 			}
 			else if (code[2] == '4')
 			{
-				itemName = "ÿc1**ÿc0Gt Heal";
+				itemName = "Ã¿c1**Ã¿c0Gt Heal";
 				displayItemLevel = false;
 			}
 			else if (code[2] == '5')
 			{
-				itemName = "ÿc1**ÿc0Sup Heal";
+				itemName = "Ã¿c1**Ã¿c0Sup Heal";
 				displayItemLevel = false;
 			}
 		}
@@ -435,27 +458,27 @@ void Item::OrigGetItemName(UnitAny *item, string &itemName, char *code)
 		{
 			if (code[2] == '1')
 			{
-				itemName = "ÿc3**ÿc0Min Mana";
+				itemName = "Ã¿c3**Ã¿c0Min Mana";
 				displayItemLevel = false;
 			}
 			else if (code[2] == '2')
 			{
-				itemName = "ÿc3**ÿc0Lt Mana";
+				itemName = "Ã¿c3**Ã¿c0Lt Mana";
 				displayItemLevel = false;
 			}
 			else if (code[2] == '3')
 			{
-				itemName = "ÿc3**ÿc0Mana";
+				itemName = "Ã¿c3**Ã¿c0Mana";
 				displayItemLevel = false;
 			}
 			else if (code[2] == '4')
 			{
-				itemName = "ÿc3**ÿc0Gt Mana";
+				itemName = "Ã¿c3**Ã¿c0Gt Mana";
 				displayItemLevel = false;
 			}
 			else if (code[2] == '5')
 			{
-				itemName = "ÿc3**ÿc0Sup Mana";
+				itemName = "Ã¿c3**Ã¿c0Sup Mana";
 				displayItemLevel = false;
 			}
 		}
@@ -463,12 +486,12 @@ void Item::OrigGetItemName(UnitAny *item, string &itemName, char *code)
 		{
 			if (code[2] == 's')
 			{
-				itemName = "ÿc;**ÿc0Rejuv";
+				itemName = "Ã¿c;**Ã¿c0Rejuv";
 				displayItemLevel = false;
 			}
 			else if (code[2] == 'l')
 			{
-				itemName = "ÿc;**ÿc0Full";
+				itemName = "Ã¿c;**Ã¿c0Full";
 				displayItemLevel = false;
 			}
 		}
@@ -564,13 +587,13 @@ void Item::OrigGetItemName(UnitAny *item, string &itemName, char *code)
 		//if( (code[0] == 'g' && code[1] == 'l'					) ||
 		//	(code[0] == 's' && code[1] == 'k' && code[2] == 'l' ) )
 		//{
-		//	itemName = "ÿc:" + itemName;
+		//	itemName = "Ã¿c:" + itemName;
 		//}
 		///*Perfect Gems*/
 		//if( (code[0] == 'g' && code[1] == 'p'                   ) ||
 		//	(code[0] == 's' && code[1] == 'k' && code[2] == 'p' ) )
 		//{
-		//	itemName = "ÿc<" + itemName;
+		//	itemName = "Ã¿c<" + itemName;
 		//}
 		/*Ethereal*/
 		if( item->pItemData->dwFlags & 0x400000 )
@@ -579,7 +602,7 @@ void Item::OrigGetItemName(UnitAny *item, string &itemName, char *code)
 			if( (code[0] == 'u'                                    ) ||
 				(code[0] == 'p' && code[1] == 'a' && code[2] >= 'b') )
 			{
-				itemName = "ÿc;" + itemName;
+				itemName = "Ã¿c;" + itemName;
 			}
 		}
 		/*Runes*/
@@ -587,33 +610,33 @@ void Item::OrigGetItemName(UnitAny *item, string &itemName, char *code)
 		{
 			if( code[1] == '0' )
 			{
-				itemName = "ÿc0" + itemName;
+				itemName = "Ã¿c0" + itemName;
 			}
 			else if( code[1] == '1' )
 			{
 				if( code[2] <= '6')
 				{
-					itemName = "ÿc4" + itemName;
+					itemName = "Ã¿c4" + itemName;
 				}
 				else
 				{
-					itemName = "ÿc8" + itemName;
+					itemName = "Ã¿c8" + itemName;
 				}
 			}
 			else if( code[1] == '2' )
 			{
 				if( code[2] <= '2' )
 				{
-					itemName = "ÿc8" + itemName;
+					itemName = "Ã¿c8" + itemName;
 				}
 				else
 				{
-					itemName = "ÿc1" + itemName;
+					itemName = "Ã¿c1" + itemName;
 				}
 			}
 			else if( code[1] == '3' )
 			{
-				itemName = "ÿc1" + itemName;
+				itemName = "Ã¿c1" + itemName;
 			}
 		}
 	}
@@ -1275,5 +1298,77 @@ void __declspec(naked) ViewInventoryPatch3_ASM()
 		mov ecx, dword ptr [edi + 0x60];
 
 		ret;
+	}
+}
+
+//seems to force alt to be down
+BOOL Item::PermShowItemsPatch1()
+{
+	return Toggles["Always Show Items"].state || D2CLIENT_GetUIState(UI_GROUND_ITEMS);
+}
+
+//these two seem to deal w/ fixing the inv/waypoints when alt is down
+BOOL Item::PermShowItemsPatch2() {
+	return Toggles["Always Show Items"].state || D2CLIENT_GetUIState(UI_GROUND_ITEMS);
+}
+
+BOOL Item::PermShowItemsPatch3() {
+	return Toggles["Always Show Items"].state || D2CLIENT_GetUIState(UI_GROUND_ITEMS);
+}
+
+
+void __declspec(naked) PermShowItemsPatch1_ASM()
+{
+	__asm {
+		call Item::PermShowItemsPatch1
+		test eax, eax
+		ret
+	}
+}
+
+
+void __declspec(naked) PermShowItemsPatch2_ASM()
+{
+	__asm {
+		call Item::PermShowItemsPatch2
+		test eax, eax
+		je orgcode
+		ret
+		orgcode :
+		mov eax, dword ptr[esp + 0x20]
+			test eax, eax
+			ret
+	}
+}
+
+
+void __declspec(naked) PermShowItemsPatch3_ASM()
+{
+	__asm {
+		push ebp
+		push esi
+		call Item::PermShowItemsPatch3
+		test eax, eax
+		pop esi
+		pop ebp
+		jz 	outcode
+		cmp ebp, 0x20
+		jge outcode
+		ret
+		outcode :
+		add dword ptr[esp], 0x38A  //to 6FB0DD89
+			ret
+	}
+}
+
+
+void __declspec(naked) PermShowItemsPatch4_ASM()
+{
+	__asm {
+		push eax
+		call Item::PermShowItemsPatch1
+		mov ecx, eax
+		pop eax
+		ret
 	}
 }

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -344,17 +344,17 @@ void __fastcall Item::ItemNamePatch(wchar_t *name, UnitAny *item)
 	}
 
 	// Some common color codes for text strings (see TextColor enum):
-	// ÿc; (purple)
-	// ÿc0 (white)
-	// ÿc1 (red)
-	// ÿc2 (green)
-	// ÿc3 (blue)
-	// ÿc4 (gold)
-	// ÿc5 (gray)
-	// ÿc6 (black)
-	// ÿc7 (tan)
-	// ÿc8 (orange)
-	// ÿc9 (yellow)
+	// \xFF" "c; (purple)
+	// \xFF" "c0 (white)
+	// \xFF" "c1 (red)
+	// \xFF" "c2 (green)
+	// \xFF" "c3 (blue)
+	// \xFF" "c4 (gold)
+	// \xFF" "c5 (gray)
+	// \xFF" "c6 (black)
+	// \xFF" "c7 (tan)
+	// \xFF" "c8 (orange)
+	// \xFF" "c9 (yellow)
 
 	/* Test code to display item codes */
 	//string test3 = test_code;
@@ -373,12 +373,12 @@ void Item::OrigGetItemName(UnitAny *item, string &itemName, char *code)
 		// We will also strip ilvls from these items
 		if (code[0] == 't' && code[1] == 's' && code[2] == 'c')  // town portal scroll
 		{
-			itemName = "ÿc2**ÿc0TP";
+			itemName = "\xFF" "c2**\xFF" "c0TP";
 			displayItemLevel = false;
 		}
 		else if (code[0] == 'i' && code[1] == 's' && code[2] == 'c')  // identify scroll
 		{
-			itemName = "ÿc2**ÿc0ID";
+			itemName = "\xFF" "c2**\xFF" "c0ID";
 			displayItemLevel = false;
 		}
 		else if (code[0] == 'v' && code[1] == 'p' && code[2] == 's')  // stamina potion
@@ -430,27 +430,27 @@ void Item::OrigGetItemName(UnitAny *item, string &itemName, char *code)
 		{
 			if (code[2] == '1')
 			{
-				itemName = "ÿc1**ÿc0Min Heal";
+				itemName = "\xFF" "c1**\xFF" "c0Min Heal";
 				displayItemLevel = false;
 			}
 			else if (code[2] == '2')
 			{
-				itemName = "ÿc1**ÿc0Lt Heal";
+				itemName = "\xFF" "c1**\xFF" "c0Lt Heal";
 				displayItemLevel = false;
 			}
 			else if (code[2] == '3')
 			{
-				itemName = "ÿc1**ÿc0Heal";
+				itemName = "\xFF" "c1**\xFF" "c0Heal";
 				displayItemLevel = false;
 			}
 			else if (code[2] == '4')
 			{
-				itemName = "ÿc1**ÿc0Gt Heal";
+				itemName = "\xFF" "c1**\xFF" "c0Gt Heal";
 				displayItemLevel = false;
 			}
 			else if (code[2] == '5')
 			{
-				itemName = "ÿc1**ÿc0Sup Heal";
+				itemName = "\xFF" "c1**\xFF" "c0Sup Heal";
 				displayItemLevel = false;
 			}
 		}
@@ -458,27 +458,27 @@ void Item::OrigGetItemName(UnitAny *item, string &itemName, char *code)
 		{
 			if (code[2] == '1')
 			{
-				itemName = "ÿc3**ÿc0Min Mana";
+				itemName = "\xFF" "c3**\xFF" "c0Min Mana";
 				displayItemLevel = false;
 			}
 			else if (code[2] == '2')
 			{
-				itemName = "ÿc3**ÿc0Lt Mana";
+				itemName = "\xFF" "c3**\xFF" "c0Lt Mana";
 				displayItemLevel = false;
 			}
 			else if (code[2] == '3')
 			{
-				itemName = "ÿc3**ÿc0Mana";
+				itemName = "\xFF" "c3**\xFF" "c0Mana";
 				displayItemLevel = false;
 			}
 			else if (code[2] == '4')
 			{
-				itemName = "ÿc3**ÿc0Gt Mana";
+				itemName = "\xFF" "c3**\xFF" "c0Gt Mana";
 				displayItemLevel = false;
 			}
 			else if (code[2] == '5')
 			{
-				itemName = "ÿc3**ÿc0Sup Mana";
+				itemName = "\xFF" "c3**\xFF" "c0Sup Mana";
 				displayItemLevel = false;
 			}
 		}
@@ -486,12 +486,12 @@ void Item::OrigGetItemName(UnitAny *item, string &itemName, char *code)
 		{
 			if (code[2] == 's')
 			{
-				itemName = "ÿc;**ÿc0Rejuv";
+				itemName = "\xFF" "c;**\xFF" "c0Rejuv";
 				displayItemLevel = false;
 			}
 			else if (code[2] == 'l')
 			{
-				itemName = "ÿc;**ÿc0Full";
+				itemName = "\xFF" "c;**\xFF" "c0Full";
 				displayItemLevel = false;
 			}
 		}
@@ -587,13 +587,13 @@ void Item::OrigGetItemName(UnitAny *item, string &itemName, char *code)
 		//if( (code[0] == 'g' && code[1] == 'l'					) ||
 		//	(code[0] == 's' && code[1] == 'k' && code[2] == 'l' ) )
 		//{
-		//	itemName = "ÿc:" + itemName;
+		//	itemName = "\xFF" "c:" + itemName;
 		//}
 		///*Perfect Gems*/
 		//if( (code[0] == 'g' && code[1] == 'p'                   ) ||
 		//	(code[0] == 's' && code[1] == 'k' && code[2] == 'p' ) )
 		//{
-		//	itemName = "ÿc<" + itemName;
+		//	itemName = "\xFF" "c<" + itemName;
 		//}
 		/*Ethereal*/
 		if( item->pItemData->dwFlags & 0x400000 )
@@ -602,7 +602,7 @@ void Item::OrigGetItemName(UnitAny *item, string &itemName, char *code)
 			if( (code[0] == 'u'                                    ) ||
 				(code[0] == 'p' && code[1] == 'a' && code[2] >= 'b') )
 			{
-				itemName = "ÿc;" + itemName;
+				itemName = "\xFF" "c;" + itemName;
 			}
 		}
 		/*Runes*/
@@ -610,33 +610,33 @@ void Item::OrigGetItemName(UnitAny *item, string &itemName, char *code)
 		{
 			if( code[1] == '0' )
 			{
-				itemName = "ÿc0" + itemName;
+				itemName = "\xFF" "c0" + itemName;
 			}
 			else if( code[1] == '1' )
 			{
 				if( code[2] <= '6')
 				{
-					itemName = "ÿc4" + itemName;
+					itemName = "\xFF" "c4" + itemName;
 				}
 				else
 				{
-					itemName = "ÿc8" + itemName;
+					itemName = "\xFF" "c8" + itemName;
 				}
 			}
 			else if( code[1] == '2' )
 			{
 				if( code[2] <= '2' )
 				{
-					itemName = "ÿc8" + itemName;
+					itemName = "\xFF" "c8" + itemName;
 				}
 				else
 				{
-					itemName = "ÿc1" + itemName;
+					itemName = "\xFF" "c1" + itemName;
 				}
 			}
 			else if( code[1] == '3' )
 			{
-				itemName = "ÿc1" + itemName;
+				itemName = "\xFF" "c1" + itemName;
 			}
 		}
 	}

--- a/BH/Modules/Item/Item.h
+++ b/BH/Modules/Item/Item.h
@@ -82,6 +82,10 @@ class Item : public Module {
 		static BOOL __stdcall OnDamagePropertyBuild(UnitAny* pItem, DamageStats* pDmgStats, int nStat, wchar_t* wOut);
 		static void __stdcall OnPropertyBuild(wchar_t* wOut, int nStat, UnitAny* pItem, int nStatParam);
 
+		static BOOL PermShowItemsPatch1();
+		static BOOL PermShowItemsPatch2();
+		static BOOL PermShowItemsPatch3();
+
 		static UnitAny* GetViewUnit();
 
 		static unsigned int GetFilterLevel() { return filterLevelSetting; }
@@ -96,6 +100,12 @@ void GetItemPropertyString_Interception();
 void ViewInventoryPatch1_ASM();
 void ViewInventoryPatch2_ASM();
 void ViewInventoryPatch3_ASM();
+
+void PermShowItemsPatch1_ASM();
+void PermShowItemsPatch2_ASM();
+void PermShowItemsPatch3_ASM();
+void PermShowItemsPatch4_ASM();
+
 struct UnitItemInfo;
 int CreateUnitItemInfo(UnitItemInfo *uInfo, UnitAny *item);
 

--- a/BH/Modules/Item/Item.h
+++ b/BH/Modules/Item/Item.h
@@ -59,6 +59,8 @@ class Item : public Module {
 		Drawing::UITab* settingsTab;
 		static unsigned int filterLevelSetting;
 		static unsigned int pingLevelSetting;
+
+		void ResetPatches();
 	public:
 
 		Item() : Module("Item") {};


### PR DESCRIPTION
fixes #84

add feature from stings maphack (https://github.com/jieaido/d2hackmap/blob/master/PermShowItem.cpp) to always display items w/o holding alt.

additionally it removes the ÿ from the file, vscode seems to have issues w/ it whenever I save the file. \xFF should function the same way here.

ex usage:
```
Always Show Items:      True, VK_SPACE
```