### PR TITLE
Feature/run tracker

### DIFF
--- a/BH/BH.cpp
+++ b/BH/BH.cpp
@@ -25,6 +25,7 @@ map<string, Toggle>* BH::MiscToggles;
 map<string, Toggle>* BH::MiscToggles2;
 map<string, bool>* BH::BnetBools;
 map<string, bool>* BH::GamefilterBools;
+map<size_t, string> BH::drops;
 
 Patch* patches[] = {
 	new Patch(Call, D2CLIENT, { 0x44230, 0x45280 }, (int)GameLoop_Interception, 7),

--- a/BH/BH.h
+++ b/BH/BH.h
@@ -10,6 +10,15 @@
 
 using namespace std;
 
+//boosts  hash_combine
+//https://stackoverflow.com/a/19195373/597419
+template <class T>
+inline void hash_combine(std::size_t& s, const T& v)
+{
+	std::hash<T> h;
+	s ^= h(v) + 0x9e3779b9 + (s << 6) + (s >> 2);
+}
+
 struct cGuardModule
 {	
 	union {
@@ -33,6 +42,7 @@ namespace BH {
 	extern map<string, Toggle>* MiscToggles2;
 	extern map<string, bool>* BnetBools;
 	extern map<string, bool>* GamefilterBools;
+	extern map<size_t, string> drops;
 	extern bool cGuardLoaded;
 	extern bool initialized;
 	extern Patch* oogDraw;

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -122,7 +122,7 @@ void Item::LoadConfig() {
 	BH::config->ReadToggle("Always Show Item Stat Ranges", "None", true, Toggles["Always Show Item Stat Ranges"]);
 	BH::config->ReadInt("Filter Level", filterLevelSetting);
 	BH::config->ReadInt("Ping Level", pingLevelSetting);
-	BH::config->ReadInt("Tracker Ping Level", trackerPingLevelSetting);
+	BH::config->ReadInt("Run Details Ping Level", trackerPingLevelSetting);
 
 	ItemDisplay::UninitializeItemRules();
 

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -59,6 +59,7 @@ RunesTxt* GetRunewordTxtById(int rwId);
 map<std::string, Toggle> Item::Toggles;
 unsigned int Item::filterLevelSetting = 0;
 unsigned int Item::pingLevelSetting = 0;
+unsigned int Item::trackerPingLevelSetting = -1;
 UnitAny* Item::viewingUnit;
 
 Patch* itemNamePatch = new Patch(Call, D2CLIENT, { 0x92366, 0x96736 }, (int)ItemName_Interception, 6);
@@ -121,6 +122,7 @@ void Item::LoadConfig() {
 	BH::config->ReadToggle("Always Show Item Stat Ranges", "None", true, Toggles["Always Show Item Stat Ranges"]);
 	BH::config->ReadInt("Filter Level", filterLevelSetting);
 	BH::config->ReadInt("Ping Level", pingLevelSetting);
+	BH::config->ReadInt("Tracker Ping Level", trackerPingLevelSetting);
 
 	ItemDisplay::UninitializeItemRules();
 

--- a/BH/Modules/Item/Item.h
+++ b/BH/Modules/Item/Item.h
@@ -59,6 +59,7 @@ class Item : public Module {
 		Drawing::UITab* settingsTab;
 		static unsigned int filterLevelSetting;
 		static unsigned int pingLevelSetting;
+		static unsigned int trackerPingLevelSetting;
 	public:
 
 		Item() : Module("Item") {};
@@ -86,6 +87,7 @@ class Item : public Module {
 
 		static unsigned int GetFilterLevel() { return filterLevelSetting; }
 		static unsigned int GetPingLevel() { return pingLevelSetting; }
+		static unsigned int GetTrackerPingLevel() { return trackerPingLevelSetting >= 0 ? trackerPingLevelSetting : pingLevelSetting; }
 
 };
 

--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -586,6 +586,12 @@ void BuildAction(string *str, Action *act) {
 	act->pingLevel = ParsePingLevel(act, "TIER");
 	act->description = ParseDescription(act);
 
+	size_t noTracking = act->name.find("%NOTRACK%");
+	if (noTracking != string::npos) {
+		act->name.replace(noTracking, 9, "");
+		act->noTracking = true;
+	}
+
 	// legacy support:
 	size_t map = act->name.find("%MAP%");
 	if (map != string::npos) {

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -554,6 +554,7 @@ struct Action {
 	int pxColor;
 	int lineColor;
 	int notifyColor;
+	bool noTracking;
 	unsigned int pingLevel;
 	Action() :
 		colorOnMap(UNDEFINED_COLOR),
@@ -564,6 +565,7 @@ struct Action {
 		notifyColor(UNDEFINED_COLOR),
 		pingLevel(0),
 		stopProcessing(true),
+		noTracking(false),
 		name(""),
 		description("") {}
 };

--- a/BH/Modules/ItemMover/ItemMover.cpp
+++ b/BH/Modules/ItemMover/ItemMover.cpp
@@ -585,6 +585,7 @@ void ItemMover::OnGamePacketRecv(BYTE* packet, bool* block) {
 				if ((item.action == ITEM_ACTION_NEW_GROUND || item.action == ITEM_ACTION_OLD_GROUND) && success) {
 					bool showOnMap = false;
 					bool nameWhitelisted = false;
+					bool noTracking = false;
 					auto color = UNDEFINED_COLOR;
 
 					for (vector<Rule*>::iterator it = MapRuleList.begin(); it != MapRuleList.end(); it++) {
@@ -597,6 +598,7 @@ void ItemMover::OnGamePacketRecv(BYTE* packet, bool* block) {
 							if (action_color != UNDEFINED_COLOR && (action_color != DEAD_COLOR || color == UNDEFINED_COLOR))
 								color = action_color;
 							showOnMap = true;
+							noTracking = (*it)->action.noTracking;
 							// break unless %CONTINUE% is used
 							if ((*it)->action.stopProcessing) break;
 						}
@@ -610,7 +612,9 @@ void ItemMover::OnGamePacketRecv(BYTE* packet, bool* block) {
 					}
 					//PrintText(1, "Item on ground: %s, %s, %s, %X", item.name.c_str(), item.code, item.attrs->category.c_str(), item.attrs->flags);
 					if(showOnMap && !(*BH::MiscToggles2)["Item Detailed Notifications"].state) {
-						ScreenInfo::AddDrop(item.name, item.x, item.y);
+						if (!noTracking && !IsTown(GetPlayerArea())) {
+							ScreenInfo::AddDrop(item.name, item.x, item.y);
+						}
 						if (color == UNDEFINED_COLOR) {
 							color = ItemColorFromQuality(item.quality);
 						}

--- a/BH/Modules/ItemMover/ItemMover.cpp
+++ b/BH/Modules/ItemMover/ItemMover.cpp
@@ -586,6 +586,7 @@ void ItemMover::OnGamePacketRecv(BYTE* packet, bool* block) {
 					bool showOnMap = false;
 					bool nameWhitelisted = false;
 					bool noTracking = false;
+					auto pingLevel = -1;
 					auto color = UNDEFINED_COLOR;
 
 					for (vector<Rule*>::iterator it = MapRuleList.begin(); it != MapRuleList.end(); it++) {
@@ -599,6 +600,7 @@ void ItemMover::OnGamePacketRecv(BYTE* packet, bool* block) {
 								color = action_color;
 							showOnMap = true;
 							noTracking = (*it)->action.noTracking;
+							pingLevel = (*it)->action.pingLevel;
 							// break unless %CONTINUE% is used
 							if ((*it)->action.stopProcessing) break;
 						}
@@ -612,7 +614,7 @@ void ItemMover::OnGamePacketRecv(BYTE* packet, bool* block) {
 					}
 					//PrintText(1, "Item on ground: %s, %s, %s, %X", item.name.c_str(), item.code, item.attrs->category.c_str(), item.attrs->flags);
 					if(showOnMap && !(*BH::MiscToggles2)["Item Detailed Notifications"].state) {
-						if (!noTracking && !IsTown(GetPlayerArea())) {
+						if (!noTracking && !IsTown(GetPlayerArea()) && pingLevel <= Item::GetTrackerPingLevel()) {
 							ScreenInfo::AddDrop(item.name, item.x, item.y);
 						}
 						if (color == UNDEFINED_COLOR) {

--- a/BH/Modules/ItemMover/ItemMover.cpp
+++ b/BH/Modules/ItemMover/ItemMover.cpp
@@ -4,6 +4,7 @@
 #include "../../D2Ptrs.h"
 #include "../../D2Stubs.h"
 #include "../../D2Helpers.h"
+#include "../ScreenInfo/ScreenInfo.h"
 
 // This module was inspired by the RedVex plugin "Item Mover", written by kaiks.
 // Thanks to kaiks for sharing his code.
@@ -609,6 +610,7 @@ void ItemMover::OnGamePacketRecv(BYTE* packet, bool* block) {
 					}
 					//PrintText(1, "Item on ground: %s, %s, %s, %X", item.name.c_str(), item.code, item.attrs->category.c_str(), item.attrs->flags);
 					if(showOnMap && !(*BH::MiscToggles2)["Item Detailed Notifications"].state) {
+						ScreenInfo::AddDrop(item.name, item.x, item.y);
 						if (color == UNDEFINED_COLOR) {
 							color = ItemColorFromQuality(item.quality);
 						}

--- a/BH/Modules/ItemMover/ItemMover.cpp
+++ b/BH/Modules/ItemMover/ItemMover.cpp
@@ -615,7 +615,7 @@ void ItemMover::OnGamePacketRecv(BYTE* packet, bool* block) {
 					//PrintText(1, "Item on ground: %s, %s, %s, %X", item.name.c_str(), item.code, item.attrs->category.c_str(), item.attrs->flags);
 					if(showOnMap && !(*BH::MiscToggles2)["Item Detailed Notifications"].state) {
 						if (!noTracking && !IsTown(GetPlayerArea()) && pingLevel <= Item::GetTrackerPingLevel()) {
-							ScreenInfo::AddDrop(item.name, item.x, item.y);
+							ScreenInfo::AddDrop(item.name.c_str(), item.x, item.y);
 						}
 						if (color == UNDEFINED_COLOR) {
 							color = ItemColorFromQuality(item.quality);

--- a/BH/Modules/Maphack/Maphack.cpp
+++ b/BH/Modules/Maphack/Maphack.cpp
@@ -392,7 +392,9 @@ void Maphack::OnDraw() {
 									start_pos += 3;
 								}
 								PrintText(ItemColorFromQuality(unit->pItemData->dwQuality), "%s", itemName.c_str());
-								ScreenInfo::AddDrop(unit);
+								if (!action.noTracking && !IsTown(GetPlayerArea())) {
+									ScreenInfo::AddDrop(unit);
+								}
 								//PrintText(ItemColorFromQuality(unit->pItemData->dwQuality), "%s %x", itemName.c_str(), dwFlags);
 								break;
 							}

--- a/BH/Modules/Maphack/Maphack.cpp
+++ b/BH/Modules/Maphack/Maphack.cpp
@@ -392,7 +392,7 @@ void Maphack::OnDraw() {
 									start_pos += 3;
 								}
 								PrintText(ItemColorFromQuality(unit->pItemData->dwQuality), "%s", itemName.c_str());
-								if (!action.noTracking && !IsTown(GetPlayerArea())) {
+								if (!action.noTracking && !IsTown(GetPlayerArea()) && action.pingLevel <= Item::GetTrackerPingLevel()) {
 									ScreenInfo::AddDrop(unit);
 								}
 								//PrintText(ItemColorFromQuality(unit->pItemData->dwQuality), "%s %x", itemName.c_str(), dwFlags);

--- a/BH/Modules/Maphack/Maphack.cpp
+++ b/BH/Modules/Maphack/Maphack.cpp
@@ -11,6 +11,7 @@
 #include "../Item/ItemDisplay.h"
 #include "../Item/Item.h"
 #include "../../AsyncDrawBuffer.h"
+#include "../ScreenInfo/ScreenInfo.h"
 
 #pragma optimize( "", off)
 
@@ -391,6 +392,7 @@ void Maphack::OnDraw() {
 									start_pos += 3;
 								}
 								PrintText(ItemColorFromQuality(unit->pItemData->dwQuality), "%s", itemName.c_str());
+								ScreenInfo::AddDrop(unit);
 								//PrintText(ItemColorFromQuality(unit->pItemData->dwQuality), "%s %x", itemName.c_str(), dwFlags);
 								break;
 							}

--- a/BH/Modules/ScreenInfo/ScreenInfo.cpp
+++ b/BH/Modules/ScreenInfo/ScreenInfo.cpp
@@ -30,7 +30,7 @@ void ScreenInfo::OnLoad() {
 	d2VersionText->SetFont(1);
 
 	if (BH::cGuardLoaded) {
-		Texthook* cGuardText = new Texthook(Perm, 790, 23, "ÿc4cGuard Loaded");
+		Texthook* cGuardText = new Texthook(Perm, 790, 23, "ï¿½c4cGuard Loaded");
 		cGuardText->SetAlignment(Right);
 	}
 	gameTimer = GetTickCount();
@@ -99,6 +99,14 @@ void ScreenInfo::OnGameJoin() {
 		title += unit->pPlayerData->szName;
 		if (!SetWindowText(D2GFX_GetHwnd(), title.c_str())) {
 			printf("Failed setting window text, error: %d\n\n", GetLastError());
+		}
+	}
+
+	if (bFailedToWrite) {
+		bFailedToWrite = false;
+		string path = ReplaceAutomapTokens(szSavePath);
+		for(int i = 0; i < 5; i++) {
+			PrintText(Red, "FILE \"%s\" IS LOCKED BY ANOTHER PROCESS! LAST RUN DATA WAS NOT SAVED!", ReplaceAutomapTokens(szSavePath));
 		}
 	}
 
@@ -389,10 +397,10 @@ void ScreenInfo::OnAutomapDraw() {
 }
 
 void ScreenInfo::AddDrop(UnitAny* pItem) {
-	ScreenInfo::AddDrop(GetItemName(pItem), pItem->pPath->xPos, pItem->pPath->yPos);
+	ScreenInfo::AddDrop(GetItemName(pItem), pItem->pItemPath->dwPosX, pItem->pItemPath->dwPosY);
 }
 
-void ScreenInfo::AddDrop(const string& name, int x, int y) {
+void ScreenInfo::AddDrop(const string& name, unsigned int x, unsigned int y) {
 	size_t h = 0;
 	hash_combine(h, hash<string>{}(name));
 	hash_combine(h, hash<long>{}(x << 8 | y));
@@ -541,6 +549,10 @@ void ScreenInfo::WriteRunTrackerData() {
 
 	std::ofstream os;
 	os.open(path, std::ios_base::app);
+	if (os.fail()) {
+		bFailedToWrite = true;
+		return;
+	}
 	if (!exist) {
 		os << ReplaceAutomapTokens(szColumnHeader) << endl; 
 	}

--- a/BH/Modules/ScreenInfo/ScreenInfo.cpp
+++ b/BH/Modules/ScreenInfo/ScreenInfo.cpp
@@ -121,6 +121,7 @@ void ScreenInfo::OnGameJoin() {
 		szLastXpPerSec = "N/A";
 		szLastGameTime = "N/A";
 	}
+	fill_n(aPlayerCountAverage, 8, 0);
 
 	BnetData* pData = (*p_D2LAUNCH_BnData);
 
@@ -157,8 +158,15 @@ void ScreenInfo::OnGameJoin() {
 	}
 	PrintText(Orange, "%d games played this session.", nTotalGames);
 	if (runname.length() > 0) {
-		PrintText(Orange, "%d \"%s\" runs this session.", runcounter[runname], runname.c_str());
+		PrintText(Orange, "%d \"%s\" games played this session.", runcounter[runname], runname.c_str());
 	}
+}
+
+int	ScreenInfo::GetPlayerCount() {
+	int i = 0;
+	for (RosterUnit* pRoster = *p_D2CLIENT_PlayerUnitList; pRoster; pRoster = pRoster->pNext)
+		++i;
+	return i;
 }
 
 string ScreenInfo::SimpleGameName(const string& gameName) {
@@ -369,7 +377,7 @@ void ScreenInfo::OnDraw() {
 	automap["PING"] = szPing;
 	automap["GAMETIME"] = gameTime;
 	automap["REALTIME"] = szTime;
-
+	aPlayerCountAverage[GetPlayerCount() - 1]++;
 
 	delete [] level;
 	
@@ -545,6 +553,14 @@ void ScreenInfo::OnGameExit() {
 	automap["LASTGAMETIME"] = szLastGameTime;
 	automap["LASTGAMETIMESEC"] = to_string(lastGameLength);
 	automap["DROPS"] = regex_replace(drops, regex("\xFF" "c."), "");
+
+	int idx = 0;
+	for (int i = 0; i < 8; i++) {
+		if (aPlayerCountAverage[i] > aPlayerCountAverage[idx]) {
+			idx = i;
+		}
+	}
+	automap["AVGPLAYERCOUNT"] = to_string(idx + 1);
 
 	MephistoBlocked = false;
 	DiabloBlocked = false;

--- a/BH/Modules/ScreenInfo/ScreenInfo.cpp
+++ b/BH/Modules/ScreenInfo/ScreenInfo.cpp
@@ -55,6 +55,8 @@ void ScreenInfo::LoadConfig() {
 	
 	BH::config->ReadToggle("Save Run Details", "None", false, Toggles["Save Run Details"]);
 	BH::config->ReadString("Save Run Details Location", szSavePath);
+
+	runDetailsColumns.clear();
 	BH::config->ReadMapList("Run Details", runDetailsColumns);
 
 	const string delimiter = ",";
@@ -502,13 +504,15 @@ void ScreenInfo::OnGameExit() {
 
 	drops = regex_replace(drops, regex("\xFF" "c."), "");
 	drops = regex_replace(drops, regex("\n"), " ");
-	drops = regex_replace(drops, regex("\\b\\d\\b\\s+"), "");
 
 	automap["GAMESTOLVL"] = szGamesToLevel;
 	automap["TIMETOLVL"] = szTimeToLevel;
+	automap["LASTXPGAINED"] = to_string(xpGained);
 	automap["LASTXPPERCENTGAINED"] = szLastXpGainPer;
 	automap["LASTXPPERSEC"] = szLastXpPerSec;
+	automap["LASTXPPERSECLONG"] = to_string(lastExpPerSecond);
 	automap["LASTGAMETIME"] = szLastGameTime;
+	automap["LASTGAMETIMESEC"] = to_string(lastGameLength);
 	automap["SESSIONGAMECOUNT"] = to_string(++nTotalGames);
 	automap["DROPS"] = regex_replace(drops, regex("\xFF" "c."), "");
 

--- a/BH/Modules/ScreenInfo/ScreenInfo.cpp
+++ b/BH/Modules/ScreenInfo/ScreenInfo.cpp
@@ -385,7 +385,7 @@ void ScreenInfo::AddDrop(UnitAny* pItem) {
 void ScreenInfo::AddDrop(const string& name, int x, int y) {
 	size_t h = 0;
 	hash_combine(h, hash<string>{}(name));
-	hash_combine(h, hash<int>{}(x << 8 | y));
+	hash_combine(h, hash<long>{}(x << 8 | y));
 	BH::drops[h] = name;
 }
 

--- a/BH/Modules/ScreenInfo/ScreenInfo.cpp
+++ b/BH/Modules/ScreenInfo/ScreenInfo.cpp
@@ -53,7 +53,7 @@ void ScreenInfo::LoadConfig() {
 
 	BH::config->ReadArray("AutomapInfo", automapInfo);
 	
-	BH::config->ReadToggle("Save Run Details", "None", true, Toggles["Save Run Details"]);
+	BH::config->ReadToggle("Save Run Details", "None", false, Toggles["Save Run Details"]);
 	BH::config->ReadString("Save Run Details Location", szSavePath);
 	BH::config->ReadMapList("Run Details", runDetailsColumns);
 

--- a/BH/Modules/ScreenInfo/ScreenInfo.cpp
+++ b/BH/Modules/ScreenInfo/ScreenInfo.cpp
@@ -49,15 +49,6 @@ void ScreenInfo::OnLoad() {
 }
 
 void ScreenInfo::LoadConfig() {
-	cRunData = new Config("Run.dat");
-	if (!cRunData->Parse()) {
-		cRunData->SetConfigName("Run.dat");
-		std::ofstream os;
-		os.open(cRunData->GetConfigName(), std::ios_base::out);
-		os << endl;
-		os.close();
-	}
-
 	BH::config->ReadToggle("Experience Meter", "VK_NUMPAD7", false, Toggles["Experience Meter"]);
 
 	BH::config->ReadArray("AutomapInfo", automapInfo);
@@ -156,16 +147,6 @@ void ScreenInfo::OnGameJoin() {
 	if (runcounter.find(runname) == runcounter.end()) {
 		runcounter[runname] = 0;
 	}
-	cRunData->ReadAssoc(pUnit->pPlayerData->szName, runs);
-	if (runs.find(runname) == runs.end()) {
-		runs[runname] = 0;
-		std::ofstream os;
-		os.open(cRunData->GetConfigName(), std::ios_base::app);
-		os << pUnit->pPlayerData->szName << "[" << runname << "]: 0" << endl;
-		os.close();
-		cRunData->Parse();
-	}
-	runcounter[runname]++, runs[runname]++;
 	automap["GAMEPASS"] = pData->szGamePass;
 	automap["GAMEDESC"] = pData->szGameDesc;
 	automap["GAMEIP"] = pData->szGameIP;
@@ -174,13 +155,43 @@ void ScreenInfo::OnGameJoin() {
 	automap["CHARNAME"] = pUnit->pPlayerData->szName;
 	automap["SESSIONGAMECOUNT"] = to_string(++nTotalGames);
 
+	/*
+	string p = ReplaceAutomapTokens(szSavePath);
+	cRunData = new Config(p + ".dat");
+	if (!cRunData->Parse()) {
+		cRunData->SetConfigName(p + ".dat");
+		std::ofstream os;
+		os.open(cRunData->GetConfigName(), std::ios_base::out);
+		os << endl;
+		os.close();
+	}
+	cRunData->ReadAssoc(pUnit->pPlayerData->szName, runs);
+	if (runs.find(runname) == runs.end()) {
+		runs[runname] = 0;
+		std::ofstream os;
+		os.open(cRunData->GetConfigName(), std::ios_base::app);
+		os << pUnit->pPlayerData->szName << "[" << runname << "]: 0" << endl;
+		os.close();
+		cRunData->Parse();
+		cRunData->ReadAssoc(pUnit->pPlayerData->szName, runs);
+	}
+	runs[runname]++;
+	*/
+	runcounter[runname]++;
+
 	if (!Toggles["Run Details On Join"].state) {
 		return;
 	}
-	PrintText(Orange, "%d games played this session.", nTotalGames);
 	if (runname.length() > 0) {
+		//mp
+		PrintText(Orange, "%d games played this session.", nTotalGames);
 		PrintText(Orange, "%d \"%s\" games played this session.", runcounter[runname], runname.c_str());
-		PrintText(Orange, "%d \"%s\" games played total.", runs[runname], runname.c_str());
+		//PrintText(Orange, "%d \"%s\" games played total.", runs[runname], runname.c_str());
+	} else {
+		//sp
+		PrintText(Orange, "%d games played this session.", nTotalGames);
+		PrintText(Orange, "%d single player games played this session.", runcounter[runname]);
+		//PrintText(Orange, "%d single player games played on this character.", runs[runname], runname.c_str());
 	}
 }
 
@@ -592,7 +603,10 @@ void ScreenInfo::OnGameExit() {
 	if (Toggles["Save Run Details"].state) {
 		WriteRunTrackerData();
 	}
+	/*
 	cRunData->Write();
+	delete cRunData;
+	*/
 }
 
 void ScreenInfo::WriteRunTrackerData() {

--- a/BH/Modules/ScreenInfo/ScreenInfo.cpp
+++ b/BH/Modules/ScreenInfo/ScreenInfo.cpp
@@ -55,7 +55,7 @@ void ScreenInfo::LoadConfig() {
 	
 	BH::config->ReadToggle("Run Tracker", "None", true, Toggles["Run Tracker"]);
 	//BH::config->ReadString("Run Tracker Save Location", szSavePath);
-	szSavePath = "../data/%CHARNAME%.csv";
+	szSavePath = "./data/%CHARNAME%.csv";
 	szColumnHeader = "\"Count\",\"Date\",\"Time\",\"Game Name\",\"Difficulty\",\"Start Level\",\"Run Length\",\"XP Gained\",\"XP/s\",\"Drops\"";
 	szColumnData = "\"%SESSIONGAMECOUNT%\",\"%JOINDATE%\",\"%JOINTIME%\",\"%GAMENAME%\",\"%GAMEDIFF%\",\"%CHARLEVELPERCENT%\",\"%LASTGAMETIME%\",\"%LASTXPPERCENTGAINED%\",=\"%LASTXPPERSEC%\",\"%DROPS%\"";
 
@@ -518,7 +518,7 @@ void ScreenInfo::WriteRunTrackerData() {
 	bool exist = fs::exists(path);
 
 	string directory;
-	const size_t last_slash_idx = path.rfind('\\');
+	const size_t last_slash_idx = path.rfind('\/');
 	if (std::string::npos != last_slash_idx)
 	{
 		directory = path.substr(0, last_slash_idx);

--- a/BH/Modules/ScreenInfo/ScreenInfo.h
+++ b/BH/Modules/ScreenInfo/ScreenInfo.h
@@ -44,6 +44,8 @@ class ScreenInfo : public Module {
 		double currentExpPerSecond;
 		char* currentExpPerSecondUnit;
 
+
+		Config* cRunData;
 		bool bFailedToWrite = false;
 		int nTotalGames;
 		string szGamesToLevel;
@@ -60,6 +62,7 @@ class ScreenInfo : public Module {
 		map<string, string> automap;
 		map<string, int> runcounter;
 		vector<pair<string, string>> runDetailsColumns;
+		map<string, unsigned int> runs;
 
 		string SimpleGameName(const string& gameName);
 		int	GetPlayerCount();

--- a/BH/Modules/ScreenInfo/ScreenInfo.h
+++ b/BH/Modules/ScreenInfo/ScreenInfo.h
@@ -44,6 +44,7 @@ class ScreenInfo : public Module {
 		double currentExpPerSecond;
 		char* currentExpPerSecondUnit;
 
+		bool bFailedToWrite = false;
 		int nTotalGames;
 		string szGamesToLevel;
 		string szTimeToLevel;
@@ -85,7 +86,7 @@ class ScreenInfo : public Module {
 		void WriteRunTrackerData();
 
 		static void AddDrop(UnitAny* item);
-		static void AddDrop(const string& name, int x, int y);
+		static void AddDrop(const string& name, unsigned int x, unsigned int y);
 };
 
 StateCode GetStateCode(unsigned int nKey);

--- a/BH/Modules/ScreenInfo/ScreenInfo.h
+++ b/BH/Modules/ScreenInfo/ScreenInfo.h
@@ -58,7 +58,8 @@ class ScreenInfo : public Module {
 		map<string, string> automap;
 
 
-		void ScreenInfo::FormattedXPPerSec(char* buffer, double xpPerSec);
+		void FormattedXPPerSec(char* buffer, double xpPerSec);
+		string FormatTime(time_t t, const char* format);
 	public:
 		static map<std::string, Toggle> Toggles;
 

--- a/BH/Modules/ScreenInfo/ScreenInfo.h
+++ b/BH/Modules/ScreenInfo/ScreenInfo.h
@@ -5,7 +5,6 @@
 #include "../../Drawing.h"
 #include <deque>
 
-
 struct StateCode {
 	std::string name;
 	unsigned int value;
@@ -52,6 +51,7 @@ class ScreenInfo : public Module {
 		string szLastXpGainPer;
 		string szLastXpPerSec;
 		string szLastGameTime;
+		int aPlayerCountAverage[8];
 
 		string szSavePath;
 		string szColumnHeader;
@@ -62,6 +62,7 @@ class ScreenInfo : public Module {
 		vector<pair<string, string>> runDetailsColumns;
 
 		string SimpleGameName(const string& gameName);
+		int	GetPlayerCount();
 		void FormattedXPPerSec(char* buffer, double xpPerSec);
 		string FormatTime(time_t t, const char* format);
 	public:

--- a/BH/Modules/ScreenInfo/ScreenInfo.h
+++ b/BH/Modules/ScreenInfo/ScreenInfo.h
@@ -56,6 +56,7 @@ class ScreenInfo : public Module {
 		string szColumnData;
 
 		map<string, string> automap;
+		vector<pair<string, string>> runDetailsColumns;
 
 
 		void FormattedXPPerSec(char* buffer, double xpPerSec);

--- a/BH/Modules/ScreenInfo/ScreenInfo.h
+++ b/BH/Modules/ScreenInfo/ScreenInfo.h
@@ -6,11 +6,6 @@
 #include <deque>
 
 
-struct AutomapReplace {
-	std::string key;
-	std::string value;
-};
-
 struct StateCode {
 	std::string name;
 	unsigned int value;
@@ -48,11 +43,20 @@ class ScreenInfo : public Module {
 		double currentExpGainPct;
 		double currentExpPerSecond;
 		char* currentExpPerSecondUnit;
+
+		int nTotalGames;
 		string szGamesToLevel;
 		string szTimeToLevel;
 		string szLastXpGainPer;
 		string szLastXpPerSec;
 		string szLastGameTime;
+
+		string szSavePath;
+		string szColumnHeader;
+		string szColumnData;
+
+		map<string, string> automap;
+
 
 		void ScreenInfo::FormattedXPPerSec(char* buffer, double xpPerSec);
 	public:
@@ -74,6 +78,9 @@ class ScreenInfo : public Module {
 		void OnDraw();
 		void OnAutomapDraw();
 		void OnGamePacketRecv(BYTE* packet, bool *block);
+
+		std::string ReplaceAutomapTokens(std::string& v);
+		void WriteRunTrackerData();
 };
 
 StateCode GetStateCode(unsigned int nKey);

--- a/BH/Modules/ScreenInfo/ScreenInfo.h
+++ b/BH/Modules/ScreenInfo/ScreenInfo.h
@@ -27,6 +27,7 @@ class ScreenInfo : public Module {
 		Drawing::Texthook* mpqVersionText;
 		Drawing::Texthook* d2VersionText;
 		DWORD gameTimer;
+		DWORD endTimer;
 
 		int packetRequests;
 		ULONGLONG warningTicks;
@@ -57,9 +58,10 @@ class ScreenInfo : public Module {
 		string szColumnData;
 
 		map<string, string> automap;
+		map<string, int> runcounter;
 		vector<pair<string, string>> runDetailsColumns;
 
-
+		string SimpleGameName(const string& gameName);
 		void FormattedXPPerSec(char* buffer, double xpPerSec);
 		string FormatTime(time_t t, const char* format);
 	public:

--- a/BH/Modules/ScreenInfo/ScreenInfo.h
+++ b/BH/Modules/ScreenInfo/ScreenInfo.h
@@ -81,6 +81,9 @@ class ScreenInfo : public Module {
 
 		std::string ReplaceAutomapTokens(std::string& v);
 		void WriteRunTrackerData();
+
+		static void AddDrop(UnitAny* item);
+		static void AddDrop(const string& name, int x, int y);
 };
 
 StateCode GetStateCode(unsigned int nKey);

--- a/BH/Modules/ScreenInfo/ScreenInfo.h
+++ b/BH/Modules/ScreenInfo/ScreenInfo.h
@@ -44,8 +44,13 @@ class ScreenInfo : public Module {
 		double currentExpPerSecond;
 		char* currentExpPerSecondUnit;
 
-
-		Config* cRunData;
+		// used to keep track of runs over the course of a season. example cfg would look like:
+		/*
+		BoBarb[quickcs]: 250
+		BoBarb[quickbaal]: 170
+		BoBarb[mf]: 500
+		*/
+		//Config* cRunData;
 		bool bFailedToWrite = false;
 		int nTotalGames;
 		string szGamesToLevel;


### PR DESCRIPTION
fixes #94. Configurable tracking of your runs, drops, xp gained. By default it will track all items notified in game when out of town. If you want to disable the tracking of a certain drop (i.e. small/grand charms) you can add `%notrack%` to that row in your item config. Still something to figure out is how to prevent duplicate drops when you go out of range and back into range for an item.

The following settings should be added to BH_settings.cfg to configure it by default.

```
Tracker Ping Level: 4
Save Run Details: True, None
Save Run Details Location: ./data/%CHARNAME%.csv

Run Details[Count]: "%SESSIONGAMECOUNT%"
Run Details[Date]: "%JOINDATE%"
Run Details[Time]: "%JOINTIME%"
Run Details[Game Name]: "%GAMENAME%"
Run Details[Difficulty]: "%GAMEDIFF%"
Run Details[Start Level]: "%CHARLEVELPERCENT%"
Run Details[Run Length (sec)]: "%LASTGAMETIMESEC%"
Run Details[XP Gained]: "%LASTXPPERCENTGAINED%"
Run Details[XP/s]: %LASTXPPERSECLONG%
Run Details[Drops]: " %DROPS%"
```

example output.

```
Count,Date,Time,Game Name,Difficulty,Start Level,Run Length (sec),XP Gained,XP/s,Drops
"35","2020-12-06","21:37:35-0500","Danny33","Hell","95.286417","255","+0.65%",5717.889764," <<< T1 Ber Rune >>>, +T4 Ring"
```

you can then open that csv in excel and do any kind of manipulation to that data u want to get average xp per run ect....

![image](https://user-images.githubusercontent.com/1458109/101057351-f1cc6d80-3559-11eb-9e28-9d5235149a6b.png)


All of the different details you can track in columns

* `%SESSIONGAMECOUNT%` - a counter of how many games you've joined this "session".
* `%DROPS%` - item drop obtained during the run.
* `%GAMESTOLVL%` - estimate of the # of games to level based on your last game.
* `%TIMETOLVL%` - estimate of the time to level based on your last game.
* `%LASTXPPERCENTGAINED%` - % xp gained during the last game
* `%LASTXPPERSEC%` - xp per sec gained during the last game (XXK/s) format
* `%LASTXPPERSECLONG%` - xp per sec gained during the last game. long format, actual number, not K/s, M/s
* `%LASTGAMETIME%` - length of the last game hh:mm:dd format
* `%LASTGAMETIMESEC%` - length of last game in seconds
* `%JOINDATE%` - date you joined game
* `%JOINTIME%` - time you joined at
* `%CHARLEVEL%` - simple char level. e.g. (95) on joining the game
* `%CHARXPPERCENT%` - percent of xp you've gained towards next level e.g. 0.65 on joining the game
* `%CHARLEVELPERCENT%` - the previous two fields added together
* `%CHARXP%` - total xp of your char on joining the game
* `%CURRENTCHARLEVEL%` - simple char level. e.g. (95) on exiting the game
* `%CURRENTCHARXPPERCENT%` - percent of xp you've gained towards next level e.g. 0.65 on exiting the game
* `%CURRENTCHARLEVELPERCENT%` - the previous two fields added together
* `%CURRENTCHARXP%` - total xp of your char on exiting the game
* `%LEVEL%` - area you were in when exiting the game
* `%PING%` - your ping when exiting the game
* `%GAMETIME%` - same as ``%LASTGAMETIME%`
* `%REALTIME%` - date time as displayed in the game upon exiting
* `%GAMENAME%` - game's name
* `%GAMEPASS%` - game's password
* `%GAMEDESC%` - game's description
* `%GAMEDIFF%` - game's difficulty
* `%ACCOUNTNAME%` - account name
* `%CHARNAME%` - char name.

