### PR TITLE
add XP and CLASSIC filter options

### DIFF
--- a/BH/Modules/Item/ItemDisplay.cpp
+++ b/BH/Modules/Item/ItemDisplay.cpp
@@ -1093,6 +1093,10 @@ void Condition::BuildConditions(vector<Condition*> &conditions, string token) {
 
 	} else if (key.compare(0, 5, "PRICE") == 0) {
 		Condition::AddOperand(conditions, new ItemPriceCondition(operation, value));
+	} else if (key.compare(0, 2, "XP") == 0) {
+		Condition::AddOperand(conditions, new PlayerTypeCondition(PLAYER_XP));
+	} else if (key.compare(0, 7, "CLASSIC") == 0) {
+	Condition::AddOperand(conditions, new PlayerTypeCondition(PLAYER_CLASSIC));
 	}
 
 	for (vector<Condition*>::iterator it = endConditions.begin(); it != endConditions.end(); it++) {
@@ -1198,6 +1202,13 @@ bool FlagsCondition::EvaluateInternalFromPacket(ItemInfo *info, Condition *arg1,
 		return info->runeword;
 	}
 	return false;
+}
+
+bool PlayerTypeCondition::EvaluateInternal(UnitItemInfo* uInfo, Condition* arg1, Condition* arg2) {
+	return ((*p_D2LAUNCH_BnData)->nCharFlags >> 5) == mode;
+}
+bool PlayerTypeCondition::EvaluateInternalFromPacket(ItemInfo* info, Condition* arg1, Condition* arg2) {
+	return ((*p_D2LAUNCH_BnData)->nCharFlags >> 5) == mode;
 }
 
 bool QualityCondition::EvaluateInternal(UnitItemInfo *uInfo, Condition *arg1, Condition *arg2) {

--- a/BH/Modules/Item/ItemDisplay.h
+++ b/BH/Modules/Item/ItemDisplay.h
@@ -15,6 +15,9 @@
 #define EXCEPTION_INVALID_ITEM_TYPE		5
 #define EXCEPTION_INVALID_GOLD_TYPE		6
 
+#define PLAYER_CLASSIC 0
+#define PLAYER_XP 1
+
 #define DEAD_COLOR        0xdead
 #define UNDEFINED_COLOR   0xbeef
 
@@ -237,6 +240,16 @@ private:
 	unsigned int flag;
 	bool EvaluateInternal(UnitItemInfo *uInfo, Condition *arg1, Condition *arg2);
 	bool EvaluateInternalFromPacket(ItemInfo *info, Condition *arg1, Condition *arg2);
+};
+
+class PlayerTypeCondition : public Condition
+{
+public:
+	PlayerTypeCondition(unsigned int m) : mode(m) { conditionType = CT_Operand; };
+private:
+	unsigned int mode;
+	bool EvaluateInternal(UnitItemInfo* uInfo, Condition* arg1, Condition* arg2);
+	bool EvaluateInternalFromPacket(ItemInfo* info, Condition* arg1, Condition* arg2);
 };
 
 class QualityCondition : public Condition


### PR DESCRIPTION
Adds the filter options XP and CLASSIC. i.e.

```
ItemDisplay[XP hp1]: XP HP1
ItemDisplay[CLASSIC hp1]: CLASSIC HP1

ItemDisplay[!CLASSIC hp2]: XP HP2
ItemDisplay[!XP hp2]: CLASSIC HP2
```