### PR TITLE
allow more items to be seen when holding alt

### DIFF
--- a/.github/workflows/build-branch.yaml
+++ b/.github/workflows/build-branch.yaml
@@ -1,0 +1,19 @@
+name: Build Branch
+
+on: workflow_dispatch
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v1.0.2
+    - uses: actions/checkout@master
+    - name: MSBuild
+      run: msbuild /t:BH:Rebuild /p:Configuration=Release BH.sln
+    - uses: actions/upload-artifact@v2
+      with:
+        name: BH.dll
+        path: Release/BH.dll

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,21 @@
+name: Pull Request Builder
+
+on:
+  pull_request:
+    types: ['opened', 'edited', 'reopened', 'synchronize']
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v1.0.2
+    - uses: actions/checkout@master
+    - name: MSBuild
+      run: msbuild /t:BH:Rebuild /p:Configuration=Release BH.sln
+    - uses: actions/upload-artifact@v2
+      with:
+        name: BH.dll
+        path: Release/BH.dll

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -159,6 +159,7 @@ void Item::LoadConfig() {
 	BH::config->ReadToggle("Alt Item Style", "None", true, Toggles["Alt Item Style"]);
 	BH::config->ReadToggle("Color Mod", "None", false, Toggles["Color Mod"]);
 	BH::config->ReadToggle("Shorten Item Names", "None", false, Toggles["Shorten Item Names"]);
+	BH::config->ReadToggle("Show More Items", "None", true, Toggles["Show More Items"]);
 	BH::config->ReadToggle("Always Show Items", "None", false, Toggles["Always Show Items"]);
 	BH::config->ReadToggle("Advanced Item Display", "None", false, Toggles["Advanced Item Display"]);
 	BH::config->ReadToggle("Item Drop Notifications", "None", false, Toggles["Item Drop Notifications"]);
@@ -215,6 +216,30 @@ void Item::ResetPatches() {
 		permShowItems4->Remove();
 		permShowItems5->Remove();
 	}
+
+	if (Toggles["Show More Items"].state) {
+		showMoreItems1->Install();
+		showMoreItems2->Install();
+		showMoreItems3->Install();
+		showMoreItems4->Install();
+		showMoreItems5->Install();
+		showMoreItems6->Install();
+		showMoreItems7->Install();
+		showMoreItems8->Install();
+		showMoreItems9->Install();
+		showMoreItems10->Install();
+	} else {
+		showMoreItems1->Remove();
+		showMoreItems2->Remove();
+		showMoreItems3->Remove();
+		showMoreItems4->Remove();
+		showMoreItems5->Remove();
+		showMoreItems6->Remove();
+		showMoreItems7->Remove();
+		showMoreItems8->Remove();
+		showMoreItems9->Remove();
+		showMoreItems10->Remove();
+	}
 }
 
 void Item::DrawSettings() {
@@ -248,6 +273,10 @@ void Item::DrawSettings() {
 
 	new Checkhook(settingsTab, 4, y, &Toggles["Shorten Item Names"].state, "Shorten Names");
 	new Keyhook(settingsTab, keyhook_x, y+2, &Toggles["Shorten Item Names"].toggle, "");
+	y += 15;
+
+	new Checkhook(settingsTab, 4, y, &Toggles["Show More Items"].state, "Show More Items");
+	new Keyhook(settingsTab, keyhook_x, y + 2, &Toggles["Show More Items"].toggle, "");
 	y += 15;
 
 	new Checkhook(settingsTab, 4, y, &Toggles["Always Show Items"].state, "Always Show Items");

--- a/BH/Modules/Item/Item.h
+++ b/BH/Modules/Item/Item.h
@@ -62,6 +62,7 @@ class Item : public Module {
 		static unsigned int filterLevelSetting;
 		static unsigned int pingLevelSetting;
 		static unsigned int trackerPingLevelSetting;
+		static LPVOID pItemBuf;
 
 		void ResetPatches();
 	public:
@@ -112,6 +113,14 @@ void PermShowItemsPatch1_ASM();
 void PermShowItemsPatch2_ASM();
 void PermShowItemsPatch3_ASM();
 void PermShowItemsPatch4_ASM();
+
+void ShowMoreItemsItemsPatch1_ASM();
+void ShowMoreItemsItemsPatch2_ASM();
+void ShowMoreItemsItemsPatch3_ASM();
+void ShowMoreItemsItemsPatch4_ASM();
+void ShowMoreItemsItemsPatch5_ASM();
+void ShowMoreItemsItemsPatch6_ASM();
+void ShowMoreItemsItemsPatch7_ASM();
 
 struct UnitItemInfo;
 int CreateUnitItemInfo(UnitItemInfo *uInfo, UnitAny *item);

--- a/BH/Patch.h
+++ b/BH/Patch.h
@@ -6,7 +6,7 @@
 class Patch;
 
 enum Dll { D2CLIENT=0,D2COMMON,D2GFX,D2LANG,D2WIN,D2NET,D2GAME,D2LAUNCH,FOG,BNCLIENT, STORM, D2CMP, D2MULTI, D2MCPCLIENT};
-enum PatchType { Jump=0xE9, Call=0xE8, NOP=0x90, Push=0x6A };
+enum PatchType { Jump=0xE9, Call=0xE8, NOP=0x90, Push=0x6A, JumpRelative = 0xEB };
 
 struct Offsets {
 	int _113c;


### PR DESCRIPTION
This allows more items to be seen when holding alt. All credits to rnd2k at DiabloMods discord.

https://discord.com/channels/539474050683240458/559314436439932936/834479708191064104

This still should be tested by some people to verify it works correctly. If items are too close to each other it still seems to hide them.