### PR TITLE
Feature/configurable stat range color

### DIFF
--- a/.github/workflows/build-branch.yaml
+++ b/.github/workflows/build-branch.yaml
@@ -1,0 +1,19 @@
+name: Build Branch
+
+on: workflow_dispatch
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v1.0.2
+    - uses: actions/checkout@master
+    - name: MSBuild
+      run: msbuild /t:BH:Rebuild /p:Configuration=Release BH.sln
+    - uses: actions/upload-artifact@v2
+      with:
+        name: BH.dll
+        path: Release/BH.dll

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,21 @@
+name: Pull Request Builder
+
+on:
+  pull_request:
+    types: ['opened', 'edited', 'reopened', 'synchronize']
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v1.0.2
+    - uses: actions/checkout@master
+    - name: MSBuild
+      run: msbuild /t:BH:Rebuild /p:Configuration=Release BH.sln
+    - uses: actions/upload-artifact@v2
+      with:
+        name: BH.dll
+        path: Release/BH.dll

--- a/BH/Modules/Item/Item.cpp
+++ b/BH/Modules/Item/Item.cpp
@@ -61,6 +61,7 @@ unordered_set<string> Item::no_ilvl_codes;
 unsigned int Item::filterLevelSetting = 0;
 unsigned int Item::pingLevelSetting = 0;
 unsigned int Item::trackerPingLevelSetting = -1;
+int Item::statRangeColor = TextColor::DarkGreen;
 UnitAny* Item::viewingUnit;
 
 Patch* itemNamePatch = new Patch(Call, D2CLIENT, { 0x92366, 0x96736 }, (int)ItemName_Interception, 6);
@@ -142,6 +143,7 @@ void Item::LoadConfig() {
 	BH::config->ReadInt("Filter Level", filterLevelSetting);
 	BH::config->ReadInt("Ping Level", pingLevelSetting);
 	BH::config->ReadInt("Run Details Ping Level", trackerPingLevelSetting);
+	BH::config->ReadInt("Stat Range Color", statRangeColor);
 
 	LoadNoIlvlCodes();
 
@@ -758,7 +760,7 @@ void __stdcall Item::OnProperties(wchar_t * wTxt)
 					L"%sBase Defense: %d %s[%d - %d]%s%s\n",
 					GetColorCode(TextColor::White).c_str(),
 					base,
-					GetColorCode(TextColor::DarkGreen).c_str(),
+					GetColorCode(statRangeColor).c_str(),
 					min, max_no_ed,
 					ebugged ? L"\377c5 Ebug" : L"",
 					GetColorCode(TextColor::White).c_str()
@@ -989,7 +991,7 @@ void __stdcall Item::OnPropertyBuild(wchar_t* wOut, int nStat, UnitAny* pItem, i
 				if (leftSpace) {
 					swprintf_s(wOut + aLen, leftSpace,
 							L" %s[%d - %d]%s",
-							GetColorCode(TextColor::DarkGreen).c_str(),
+							GetColorCode(statRangeColor).c_str(),
 							statMin,
 							statMax,
 							GetColorCode(TextColor::Blue).c_str());
@@ -1027,7 +1029,7 @@ void __stdcall Item::OnPropertyBuild(wchar_t* wOut, int nStat, UnitAny* pItem, i
 					if (leftSpace)
 						swprintf_s(wOut + aLen, leftSpace,
 								L" %s[%d - %d]%s",
-								GetColorCode(TextColor::DarkGreen).c_str(),
+								GetColorCode(statRangeColor).c_str(),
 								statMin,
 								statMax,
 								GetColorCode(TextColor::Blue).c_str());
@@ -1108,7 +1110,7 @@ void __stdcall Item::OnPropertyBuild(wchar_t* wOut, int nStat, UnitAny* pItem, i
 				if (leftSpace)
 					swprintf_s(wOut + aLen, leftSpace,
 							L" %s[%d - %d]%s",
-							GetColorCode(TextColor::DarkGreen).c_str(),
+							GetColorCode(statRangeColor).c_str(),
 							min,
 							max,
 							GetColorCode(TextColor::Blue).c_str());

--- a/BH/Modules/Item/Item.h
+++ b/BH/Modules/Item/Item.h
@@ -62,6 +62,7 @@ class Item : public Module {
 		static unsigned int filterLevelSetting;
 		static unsigned int pingLevelSetting;
 		static unsigned int trackerPingLevelSetting;
+		static int statRangeColor;
 
 		void ResetPatches();
 	public:


### PR DESCRIPTION
Using the following config
```
Stat Range Color: 1
```
will result in
![image](https://user-images.githubusercontent.com/1458109/132687557-0da29a22-33a8-47f3-92f8-7158e4bea4bb.png)
